### PR TITLE
[Feature] assume roles into other accounts to deploy

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1,6 +1,10 @@
 package aws
 
 import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
@@ -8,42 +12,75 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/sfn"
 	"github.com/aws/aws-sdk-go/service/sfn/sfniface"
+	"github.com/coinbase/step/utils/to"
 )
+
+////////////
+// Interfaces
+////////////
 
 type S3API s3iface.S3API
 type LambdaAPI lambdaiface.LambdaAPI
 type SFNAPI sfniface.SFNAPI
 
 type AwsClients interface {
-	S3Client() S3API
-	LambdaClient() LambdaAPI
-	SFNClient() SFNAPI
+	S3Client(region *string, account_id *string, role *string) S3API
+	LambdaClient(region *string, account_id *string, role *string) LambdaAPI
+	SFNClient(region *string, account_id *string, role *string) SFNAPI
 }
 
+////////////
+// AWS Clients
+////////////
+
 type AwsClientsStr struct {
+	session *session.Session
+	configs map[string]*aws.Config
+
 	s3Client     S3API
 	lambdaClient LambdaAPI
 	sfnClient    SFNAPI
 }
 
-func (awsc *AwsClientsStr) S3Client() S3API {
-	return awsc.s3Client
-}
-
-func (awsc *AwsClientsStr) LambdaClient() LambdaAPI {
-	return awsc.lambdaClient
-}
-
-func (awsc *AwsClientsStr) SFNClient() SFNAPI {
-	return awsc.sfnClient
-}
-
-func CreateAwsClients() AwsClients {
-	sess := session.Must(session.NewSession())
-
-	return &AwsClientsStr{
-		s3.New(sess),
-		lambda.New(sess),
-		sfn.New(sess),
+func (awsc *AwsClientsStr) getSession() *session.Session {
+	if awsc.session != nil {
+		return awsc.session
 	}
+	awsc.session = session.Must(session.NewSession())
+	return awsc.session
+}
+
+func (awsc *AwsClientsStr) getConfig(region *string, account_id *string, role *string) *aws.Config {
+	if account_id == nil || region == nil || role == nil {
+		return nil
+	}
+
+	if awsc.configs == nil {
+		awsc.configs = map[string]*aws.Config{}
+	}
+
+	key := fmt.Sprintf("%v--::--%v--::--%v", *region, *account_id, *role)
+	config, ok := awsc.configs[key]
+	if ok && config != nil {
+		return config
+	}
+
+	arn := to.RoleArn(account_id, role)
+	creds := stscreds.NewCredentials(awsc.session, *arn)
+	config = aws.NewConfig().WithCredentials(creds).WithRegion(*region)
+
+	awsc.configs[key] = config
+	return config
+}
+
+func (awsc *AwsClientsStr) S3Client(region *string, account_id *string, role *string) S3API {
+	return s3.New(awsc.getSession(), awsc.getConfig(region, account_id, role))
+}
+
+func (awsc *AwsClientsStr) LambdaClient(region *string, account_id *string, role *string) LambdaAPI {
+	return lambda.New(awsc.getSession(), awsc.getConfig(region, account_id, role))
+}
+
+func (awsc *AwsClientsStr) SFNClient(region *string, account_id *string, role *string) SFNAPI {
+	return sfn.New(awsc.getSession(), awsc.getConfig(region, account_id, role))
 }

--- a/aws/mocks/mocks.go
+++ b/aws/mocks/mocks.go
@@ -8,20 +8,19 @@ type MockAwsClientsStr struct {
 	SFN    *MockSFNClient
 }
 
-func (awsc *MockAwsClientsStr) S3Client() aws.S3API {
+func (awsc *MockAwsClientsStr) S3Client(*string, *string, *string) aws.S3API {
 	return awsc.S3
 }
 
-func (awsc *MockAwsClientsStr) LambdaClient() aws.LambdaAPI {
+func (awsc *MockAwsClientsStr) LambdaClient(*string, *string, *string) aws.LambdaAPI {
 	return awsc.Lambda
 }
 
-func (awsc *MockAwsClientsStr) SFNClient() aws.SFNAPI {
+func (awsc *MockAwsClientsStr) SFNClient(*string, *string, *string) aws.SFNAPI {
 	return awsc.SFN
 }
 
 func MockAwsClients() *MockAwsClientsStr {
-
 	return &MockAwsClientsStr{
 		&MockS3Client{},
 		&MockLambdaClient{},

--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
+	"io/ioutil"
 	"strings"
 	"time"
 
@@ -180,23 +180,17 @@ func BucketExists(s3c aws.S3API, bucket *string) error {
 // PutFile uploads a file to S3
 func PutFile(s3c aws.S3API, file_path *string, bucket *string, s3_file_path *string) error {
 	// Open the file
-	file, err := os.Open(*file_path)
+	bts, err := ioutil.ReadFile(*file_path)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-
-	fileInfo, _ := file.Stat()
-	var size int64 = fileInfo.Size()
-	buffer := make([]byte, size)
-	file.Read(buffer)
 
 	_, err = s3c.PutObject(&s3.PutObjectInput{
 		Bucket:        bucket,
 		Key:           s3_file_path,
-		Body:          bytes.NewReader(buffer),
+		Body:          bytes.NewReader(bts),
 		ACL:           to.Strp("private"),
-		ContentLength: to.Int64p(size),
+		ContentLength: to.Int64p(int64(len(bts))),
 		ContentType:   to.Strp("application/zip"),
 	})
 

--- a/deployer/client/bootstrap.go
+++ b/deployer/client/bootstrap.go
@@ -2,7 +2,7 @@ package client
 
 import (
 	"fmt"
-	"os"
+	"io/ioutil"
 
 	"github.com/coinbase/step/aws"
 	"github.com/coinbase/step/deployer"
@@ -19,7 +19,7 @@ func Bootstrap(release *deployer.Release, zip_file_path *string) error {
 		return err
 	}
 
-	bts, err := fileBytes(zip_file_path)
+	bts, err := ioutil.ReadFile(*zip_file_path)
 	if err != nil {
 		return err
 	}
@@ -34,25 +34,11 @@ func Bootstrap(release *deployer.Release, zip_file_path *string) error {
 
 	fmt.Println("Deploying Lambda Function")
 
-	err = release.DeployLambdaCode(awsc.LambdaClient(nil, nil, nil), bts)
+	err = release.DeployLambdaCode(awsc.LambdaClient(nil, nil, nil), &bts)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Success")
 	return nil
-}
-
-func fileBytes(file_path *string) (*[]byte, error) {
-	file, err := os.Open(*file_path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	fileInfo, _ := file.Stat()
-	var size int64 = fileInfo.Size()
-	buffer := make([]byte, size)
-	file.Read(buffer)
-	return &buffer, nil
 }

--- a/deployer/client/bootstrap.go
+++ b/deployer/client/bootstrap.go
@@ -2,34 +2,57 @@ package client
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/coinbase/step/aws"
+	"github.com/coinbase/step/deployer"
 	"github.com/coinbase/step/utils/to"
 )
 
 // Bootstrap takes release information and uploads directly to Step Function and Lambda
-func Bootstrap(states *string, lambda *string, step *string, bucket *string, zip_file_path *string) error {
-	awsc := aws.CreateAwsClients()
+func Bootstrap(release *deployer.Release, zip_file_path *string) error {
+	awsc := &aws.AwsClientsStr{}
 
 	fmt.Println("Preparing Release Bundle")
-	release, err := PrepareReleaseBundle(awsc, states, lambda, step, bucket, zip_file_path)
+	err := PrepareRelease(release, zip_file_path)
+	if err != nil {
+		return err
+	}
+
+	bts, err := fileBytes(zip_file_path)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Deploying Step Function")
 	fmt.Println(to.PrettyJSONStr(release))
-	err = release.DeployStepFunction(awsc.SFNClient())
+
+	err = release.DeployStepFunction(awsc.SFNClient(nil, nil, nil))
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Deploying Lambda Function")
-	err = release.DeployLambda(awsc.LambdaClient())
+
+	err = release.DeployLambdaCode(awsc.LambdaClient(nil, nil, nil), bts)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Success")
 	return nil
+}
+
+func fileBytes(file_path *string) (*[]byte, error) {
+	file, err := os.Open(*file_path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	fileInfo, _ := file.Stat()
+	var size int64 = fileInfo.Size()
+	buffer := make([]byte, size)
+	file.Read(buffer)
+	return &buffer, nil
 }

--- a/deployer/client/client.go
+++ b/deployer/client/client.go
@@ -1,73 +1,58 @@
 package client
 
 import (
-	"time"
-
 	"github.com/coinbase/step/aws"
 	"github.com/coinbase/step/aws/s3"
 	"github.com/coinbase/step/deployer"
+	"github.com/coinbase/step/machine"
 	"github.com/coinbase/step/utils/to"
 )
 
-// NewRelease returns a valid Release Structure
-func NewRelease(states *string, lambda *string, step *string, bucket *string, region *string, account_id *string, lambda_sha *string) *deployer.Release {
-	r := &deployer.Release{
-		ReleaseId:        to.TimeUUID("release-"),
-		CreatedAt:        to.Timep(time.Now()),
-		LambdaName:       lambda,
-		StepFnName:       step,
-		Bucket:           bucket,
-		StateMachineJSON: to.Strp(to.CompactJSONStr(states)),
-		LambdaSHA256:     lambda_sha,
-	}
-
-	r.SetDefaults(region, account_id)
-	return r
-}
-
-// PrepareRelease returns a release with additional information filled in by querying AWS
-func PrepareRelease(awsc aws.AwsClients, states *string, lambda *string, step *string, bucket *string, zip_file_path *string) (*deployer.Release, error) {
+// PrepareRelease returns a release with additional information filled in
+func PrepareRelease(release *deployer.Release, zip_file_path *string) error {
 	region, account_id := to.RegionAccount()
+	release.SetDefaults(region, account_id)
 
 	lambda_sha, err := to.SHA256File(*zip_file_path)
-
 	if err != nil {
-		return nil, err
+		return err
+	}
+	release.LambdaSHA256 = &lambda_sha
+
+	// Add the lambda resource to Tasks with nil resource
+	state_machine, err := machine.FromJSON([]byte(*release.StateMachineJSON))
+	if err != nil {
+		return err
 	}
 
-	release := NewRelease(states, lambda, step, bucket, region, account_id, &lambda_sha)
+	lambda_arn := to.LambdaArn(release.AwsRegion, release.AwsAccountID, release.LambdaName)
+	state_machine.SetResource(lambda_arn)
+	release.StateMachineJSON = to.Strp(to.CompactJSONStr(state_machine))
 
-	// We get the release values from the lambda
-	project, config, _, err := release.LambdaProjectConfigDeployerTags(awsc.LambdaClient())
-
-	if err != nil {
-		return nil, err
-	}
-
-	release.ProjectName = project
-	release.ConfigName = config
-
-	return release, release.ValidateClientAttributes()
+	return release.ValidateClientAttributes()
 }
 
 // PrepareReleaseDeploy builds and uploads necessary info for a deploy
-func PrepareReleaseBundle(awsc aws.AwsClients, states *string, lambda *string, step *string, bucket *string, zip_file_path *string) (*deployer.Release, error) {
-	release, err := PrepareRelease(awsc, states, lambda, step, bucket, zip_file_path)
-	if err != nil {
-		return nil, err
+func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_file_path *string) error {
+	if err := PrepareRelease(release, zip_file_path); err != nil {
+		return err
 	}
 
-	err = s3.PutFile(
-		awsc.S3Client(),
+	err := s3.PutFile(
+		awsc.S3Client(nil, nil, nil),
 		zip_file_path,
 		release.Bucket,
 		release.LambdaZipPath(),
 	)
 
-	// Uploading the SHA of the
-	if err := s3.PutStruct(awsc.S3Client(), release.Bucket, release.ReleasePath(), release); err != nil {
-		return nil, err
+	if err != nil {
+		return err
 	}
 
-	return release, nil
+	// Uploading the SHA of the
+	if err := s3.PutStruct(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleasePath(), release); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/deployer/client/client.go
+++ b/deployer/client/client.go
@@ -49,7 +49,7 @@ func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_fi
 		return err
 	}
 
-	// Uploading the SHA of the
+	// Uploading the Release to S3 to match SHAs
 	if err := s3.PutStruct(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleasePath(), release); err != nil {
 		return err
 	}

--- a/deployer/client/client.go
+++ b/deployer/client/client.go
@@ -32,7 +32,7 @@ func PrepareRelease(release *deployer.Release, zip_file_path *string) error {
 	return release.ValidateClientAttributes()
 }
 
-// PrepareReleaseDeploy builds and uploads necessary info for a deploy
+// PrepareReleaseBundle builds and uploads necessary info for a deploy
 func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_file_path *string) error {
 	if err := PrepareRelease(release, zip_file_path); err != nil {
 		return err

--- a/deployer/client/client_test.go
+++ b/deployer/client/client_test.go
@@ -2,69 +2,35 @@ package client
 
 import (
 	"testing"
+	"time"
 
-	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/coinbase/step/aws/mocks"
+	"github.com/coinbase/step/deployer"
 	"github.com/coinbase/step/machine"
 	"github.com/coinbase/step/utils/to"
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Client_NewRelease(t *testing.T) {
-	release := NewRelease(
-		to.Strp(machine.EmptyStateMachine),
-		to.Strp("lambda_name"),
-		to.Strp("step"),
-		to.Strp("bucket"),
-		to.Strp("region"),
-		to.Strp("account_id"),
-		to.Strp("lambda_sha"),
-	)
-
-	release.ProjectName = to.Strp("project")
-	release.ConfigName = to.Strp("config")
-
-	assert.NoError(t, release.ValidateClientAttributes())
-}
-
-func Test_Client_PrepareRelease(t *testing.T) {
-	awsc := mocks.MockAwsClients()
-	awsc.Lambda.ListTagsResp = &lambda.ListTagsOutput{
-		Tags: map[string]*string{"ProjectName": to.Strp("ProjectStep"), "ConfigName": to.Strp("Configy")},
-	}
-
-	release, err := PrepareRelease(
-		awsc,
-		to.Strp(machine.EmptyStateMachine),
-		to.Strp("lambda_name"),
-		to.Strp("step"),
-		to.Strp("bucket"),
-		to.Strp("../../resources/empty_lambda.zip"), // Location to empty zip file
-	)
-
-	assert.NoError(t, err)
-	assert.Equal(t, "ProjectStep", *release.ProjectName)
-	assert.Equal(t, "Configy", *release.ConfigName)
-	assert.NoError(t, release.ValidateClientAttributes())
-}
-
 func Test_Client_PrepareReleaseBundle(t *testing.T) {
 	awsc := mocks.MockAwsClients()
-	awsc.Lambda.ListTagsResp = &lambda.ListTagsOutput{
-		Tags: map[string]*string{"ProjectName": to.Strp("ProjectStep"), "ConfigName": to.Strp("Configy")},
+	release := &deployer.Release{
+		ReleaseId:        to.TimeUUID("release-"),
+		CreatedAt:        to.Timep(time.Now()),
+		ProjectName:      to.Strp("project"),
+		ConfigName:       to.Strp("project"),
+		LambdaName:       to.Strp("project"),
+		StepFnName:       to.Strp("project"),
+		Bucket:           to.Strp("project"),
+		StateMachineJSON: to.Strp(machine.EmptyStateMachine),
+		AwsRegion:        to.Strp("project"),
+		AwsAccountID:     to.Strp("project"),
 	}
 
-	release, err := PrepareReleaseBundle(
+	err := PrepareReleaseBundle(
 		awsc,
-		to.Strp(machine.EmptyStateMachine),
-		to.Strp("lambda_name"),
-		to.Strp("step"),
-		to.Strp("bucket"),
+		release,
 		to.Strp("../../resources/empty_lambda.zip"), // Location to empty zip file
 	)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "ProjectStep", *release.ProjectName)
-	assert.Equal(t, "Configy", *release.ConfigName)
-	assert.NoError(t, release.ValidateClientAttributes())
 }

--- a/deployer/client/deploy.go
+++ b/deployer/client/deploy.go
@@ -11,18 +11,18 @@ import (
 )
 
 // Deploy takes release information and Calls the Step Deployer to deploy the release
-func Deploy(states *string, lambda *string, step *string, bucket *string, zip_file_path *string, deployer_arn *string) error {
-	awsc := aws.CreateAwsClients()
+func Deploy(release *deployer.Release, zip_file_path *string, deployer_arn *string) error {
+	awsc := &aws.AwsClientsStr{}
 
 	fmt.Println("Preparing Release Bundle")
-	release, err := PrepareReleaseBundle(awsc, states, lambda, step, bucket, zip_file_path)
+	err := PrepareReleaseBundle(awsc, release, zip_file_path)
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Preparing Deploy")
 	fmt.Println(to.PrettyJSONStr(release))
-	err = sendDeployToDeployer(awsc.SFNClient(), release.ReleaseId, release, deployer_arn)
+	err = sendDeployToDeployer(awsc.SFNClient(nil, nil, nil), release.ReleaseId, release, deployer_arn)
 	if err != nil {
 		return err
 	}

--- a/deployer/helpers_test.go
+++ b/deployer/helpers_test.go
@@ -67,7 +67,7 @@ func createTestStateMachine(t *testing.T, awsc *mocks.MockAwsClientsStr) *machin
 }
 
 func assertNoLock(t *testing.T, awsc aws.AwsClients, release *Release) {
-	_, err := s3.Get(awsc.S3Client(), release.Bucket, release.LockPath())
+	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.LockPath())
 	assert.Error(t, err) // Not found error
 	assert.IsType(t, &s3.NotFoundError{}, err)
 }

--- a/deployer/integration_test.go
+++ b/deployer/integration_test.go
@@ -39,8 +39,20 @@ func Test_DeployHandler_Execution_Works(t *testing.T) {
 	}, state_machine.ExecutionPath())
 }
 
-// TODO cannot overriwte UUID
-// TODO cannot overrwite ReleaseSHA256
+func Test_DeployHandler_Execution_NoUUIDorSHA_Override(t *testing.T) {
+	release := MockRelease()
+	release.UUID = to.Strp("badString")
+	release.ReleaseSHA256 = "badString"
+
+	awsc := MockAwsClients(release)
+	state_machine := createTestStateMachine(t, awsc)
+
+	output, err := state_machine.ExecuteToMap(release)
+	assert.NoError(t, err)
+	assert.Equal(t, output["success"], true)
+	assert.NotEqual(t, output["uuid"], "badString")
+	assert.NotEqual(t, output["release_sha256"], "badString")
+}
 
 /////////
 // UNHAPPY PATH :(

--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -24,7 +24,7 @@ func StateMachine() (*machine.StateMachine, error) {
         "Catch": [
           {
             "Comment": "Bad Release or Error GoTo end",
-            "ErrorEquals": ["BadReleaseError", "UnmarshalError"],
+            "ErrorEquals": ["BadReleaseError", "UnmarshalError", "PanicError"],
             "ResultPath": "$.error",
             "Next": "FailureClean"
           }
@@ -49,7 +49,7 @@ func StateMachine() (*machine.StateMachine, error) {
           },
           {
             "Comment": "Try Release Lock Then Fail",
-            "ErrorEquals": ["LockError"],
+            "ErrorEquals": ["LockError", "PanicError"],
             "ResultPath": "$.error",
             "Next": "ReleaseLockFailureFn"
           }
@@ -68,7 +68,7 @@ func StateMachine() (*machine.StateMachine, error) {
         "Catch": [
           {
             "Comment": "Try Release Lock Then Fail",
-            "ErrorEquals": ["BadReleaseError"],
+            "ErrorEquals": ["BadReleaseError", "PanicError"],
             "ResultPath": "$.error",
             "Next": "ReleaseLockFailureFn"
           }
@@ -93,7 +93,7 @@ func StateMachine() (*machine.StateMachine, error) {
           },
           {
             "Comment": "Unsure of State, Leave Lock and Fail",
-            "ErrorEquals": ["DeployLambdaError"],
+            "ErrorEquals": ["DeployLambdaError", "PanicError"],
             "ResultPath": "$.error",
             "Next": "FailureDirty"
           }
@@ -116,7 +116,7 @@ func StateMachine() (*machine.StateMachine, error) {
           "IntervalSeconds": 30
         }],
         "Catch": [{
-          "ErrorEquals": ["LockError"],
+          "ErrorEquals": ["LockError", "PanicError"],
           "ResultPath": "$.error",
           "Next": "FailureDirty"
         }]
@@ -145,8 +145,7 @@ func StateMachineWithTaskHandlers() (*machine.StateMachine, error) {
 		return nil, err
 	}
 
-	awsc := aws.CreateAwsClients()
-	AddStateMachineHandlers(state_machine, awsc)
+	AddStateMachineHandlers(state_machine, &aws.AwsClientsStr{})
 
 	return state_machine, nil
 }

--- a/deployer/release_test.go
+++ b/deployer/release_test.go
@@ -25,9 +25,13 @@ func Test_Release_DeployStepFunction(t *testing.T) {
 
 func Test_Release_DeployLambda(t *testing.T) {
 	lambdaClient := &mocks.MockLambdaClient{}
-	r := MockRelease()
+	s3c := &mocks.MockS3Client{}
 
-	err := r.DeployLambda(lambdaClient)
+	r := MockRelease()
+	r.Bucket = to.Strp("bucket")
+	s3c.AddGetObject(*r.LambdaZipPath(), "", nil)
+
+	err := r.DeployLambda(lambdaClient, s3c)
 	assert.NoError(t, err)
 
 }

--- a/scripts/bootstrap
+++ b/scripts/bootstrap
@@ -6,7 +6,12 @@ set -e
 ./scripts/build_lambda_zip
 
 go build && go install
-step bootstrap -lambda "coinbase-step-deployer" -step "coinbase-step-deployer" -states "$(step json)"
+step bootstrap                     \
+  -lambda "coinbase-step-deployer" \
+  -step "coinbase-step-deployer"   \
+  -states "$(step json)"           \
+  -project "coinbase/step-deployer"\
+  -config "development"
 
 rm lambda.zip
 

--- a/scripts/deploy_deployer
+++ b/scripts/deploy_deployer
@@ -7,6 +7,11 @@ set -e
 ./scripts/build_lambda_zip
 
 go build && go install
-step deploy -lambda "coinbase-step-deployer" -step "coinbase-step-deployer" -states "$(step json)"
+step deploy \
+  -lambda "coinbase-step-deployer" \
+  -step "coinbase-step-deployer"   \
+  -states "$(step json)"           \
+  -project "coinbase/step-deployer"\
+  -config "development"
 
 rm lambda.zip

--- a/utils/to/arn.go
+++ b/utils/to/arn.go
@@ -19,6 +19,10 @@ func StepArn(region *string, account_id *string, name_or_arn *string) *string {
 	return createArn("arn:aws:states:%v:%v:stateMachine:%v", region, account_id, name_or_arn)
 }
 
+func RoleArn(account_id *string, name_or_arn *string) *string {
+	return createArn("arn:aws:iam::%v%v:role/%v", account_id, Strp(""), name_or_arn)
+}
+
 func ArnPath(arn string) string {
 	_, _, res := ArnRegionAccountResource(arn)
 

--- a/utils/to/pointer.go
+++ b/utils/to/pointer.go
@@ -12,7 +12,7 @@ func Strp(s string) *string {
 
 func Strs(s *string) string {
 	if s == nil {
-		return "<nil>"
+		return ""
 	}
 	return *s
 }

--- a/utils/to/pointer.go
+++ b/utils/to/pointer.go
@@ -37,6 +37,10 @@ func Boolp(s bool) *bool {
 	return &s
 }
 
+func ABytep(s []byte) *[]byte {
+	return &s
+}
+
 ////////
 // Base64
 ////////


### PR DESCRIPTION
This PR mostly adds the ability for the deployer to assume roles into other accounts and deploy there, including updates to resources.

 It also:
1. simplifies and improves deploy and bootstrap commands
2. fixes a few bugs illuminated by assume-role-setup
3. checks for panics in state-machine 