### PR TITLE
[Refactor] Common Errors and TaskFn abstraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,6 @@ RUN ./scripts/build_lambda_zip
 RUN shasum -a 256 lambda.zip | awk '{print $1}' > lambda.zip.sha256
 
 RUN mv lambda.zip.sha256 lambda.zip /
-RUN step json -lambda "%lambda%" > /state_machine.json
+RUN step json > /state_machine.json
 
 CMD ["step"]

--- a/deployer/integration_test.go
+++ b/deployer/integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/coinbase/step/machine"
 	"github.com/coinbase/step/utils/to"
 	"github.com/stretchr/testify/assert"
 )
@@ -27,14 +28,14 @@ func Test_DeployHandler_Execution_Works(t *testing.T) {
 
 	assertNoLock(t, awsc, release)
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"DeployFn",
+		machine.TaskFnName("ValidateResources"),
 		"Deploy",
+		machine.TaskFnName("Deploy"),
 		"Success",
 	}, state_machine.ExecutionPath())
 }
@@ -71,8 +72,8 @@ func Test_DeployHandler_Execution_Errors_BadInput(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
+		machine.TaskFnName("Validate"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -93,8 +94,8 @@ func Test_DeployHandler_Execution_Errors_Release(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
+		machine.TaskFnName("Validate"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -115,8 +116,8 @@ func Test_DeployHandler_Execution_Errors_CreatedAt(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
+		machine.TaskFnName("Validate"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -138,12 +139,12 @@ func Test_DeployHandler_Execution_Errors_LockError(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("Lock"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -163,10 +164,10 @@ func Test_DeployHandler_Execution_Errors_LockExistsError(t *testing.T) {
 	assert.Regexp(t, "Lock Already Exists", state_machine.LastOutput())
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
+		machine.TaskFnName("Lock"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -188,14 +189,14 @@ func Test_DeployHandler_Execution_Errors_WrongLambdaTags(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("ValidateResources"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -216,14 +217,14 @@ func Test_DeployHandler_Execution_Errors_WrongSFNPath(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("ValidateResources"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -242,14 +243,14 @@ func Test_DeployHandler_Execution_Errors_BadLambdaSHA(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("ValidateResources"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -268,14 +269,14 @@ func Test_DeployHandler_Execution_Errors_BadReleasePath(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("ValidateResources"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -294,14 +295,14 @@ func Test_DeployHandler_Execution_Errors_WrongReleasePath(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("ValidateResources"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -321,14 +322,14 @@ func Test_DeployHandler_Execution_Errors_DifferentReleaseSHA(t *testing.T) {
 	assertNoLock(t, awsc, release)
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("ValidateResources"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -349,16 +350,16 @@ func Test_DeployHandler_Execution_Errors_DeploySFNError(t *testing.T) {
 	assert.Regexp(t, "AWSSFNError", state_machine.LastOutput())
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"DeployFn",
+		machine.TaskFnName("ValidateResources"),
 		"Deploy",
-		"ReleaseLockFailureFn",
+		machine.TaskFnName("Deploy"),
 		"ReleaseLockFailure",
+		machine.TaskFnName("ReleaseLockFailure"),
 		"FailureClean",
 	}, state_machine.ExecutionPath())
 }
@@ -377,14 +378,14 @@ func Test_DeployHandler_Execution_Errors_DeployLambdaError(t *testing.T) {
 	assert.Regexp(t, "AWSLambdaError", state_machine.LastOutput())
 
 	assert.Equal(t, []string{
-		"ValidateFn",
 		"Validate",
-		"LockFn",
+		machine.TaskFnName("Validate"),
 		"Lock",
-		"ValidateResourcesFn",
+		machine.TaskFnName("Lock"),
 		"ValidateResources",
-		"DeployFn",
+		machine.TaskFnName("ValidateResources"),
 		"Deploy",
+		machine.TaskFnName("Deploy"),
 		"FailureDirty",
 	}, state_machine.ExecutionPath())
 }

--- a/examples/taskfn.json
+++ b/examples/taskfn.json
@@ -1,0 +1,32 @@
+{
+  "Comment": "Contrived Valid Example that should have all State types",
+  "StartAt": "Pass",
+  "States": {
+    "TaskFn": {
+      "Type": "TaskFn",
+      "Resource": "asd",
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "CustomError1",
+            "CustomError2"
+          ],
+          "ResultPath": "$.asd",
+          "Next": "Pass"
+        }
+      ],
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "CustomError1",
+            "CustomError2"
+          ],
+          "IntervalSeconds": 3,
+          "MaxAttempts": 10,
+          "BackoffRate": 2.5
+        }
+      ],
+      "End": true
+    }
+  }
+}

--- a/execution/execution.go
+++ b/execution/execution.go
@@ -38,6 +38,7 @@ func StartExecutionRaw(sfnc sfniface.SFNAPI, arn *string, name *string, input_js
 
 	return &Execution{ExecutionArn: out.ExecutionArn, StartDate: out.StartDate}, nil
 }
+
 func FindExecution(sfnc sfniface.SFNAPI, arn *string, name_prefix string) (*Execution, error) {
 	// TODO search through pages for first match
 	out, err := sfnc.ListExecutions(&sfn.ListExecutionsInput{

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -73,6 +73,21 @@ func (sm *StateMachine) ExecuteJSON(input *string) (*string, error) {
 }
 
 func (sm *StateMachine) ExecuteToMap(input interface{}) (map[string]interface{}, error) {
+	switch input.(type) {
+	case string:
+		var json_input map[string]interface{}
+		if err := json.Unmarshal([]byte(input.(string)), &json_input); err != nil {
+			return nil, err
+		}
+		input = json_input
+	case *string:
+		var json_input map[string]interface{}
+		if err := json.Unmarshal([]byte(*(input.(*string))), &json_input); err != nil {
+			return nil, err
+		}
+		input = json_input
+	}
+
 	output, err := sm.Execute(input)
 	switch output.(type) {
 	case map[string]interface{}:

--- a/machine/machine_test.go
+++ b/machine/machine_test.go
@@ -79,7 +79,7 @@ func Test_Machine_NoTaskShouldError(t *testing.T) {
 
 	_, err := executeJSON(json, make(map[string]interface{}), t)
 	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "TaskError(start): $.Task input incorrect with <nil>")
+	assert.Equal(t, err.Error(), "TaskError(start): $.Task input is nil")
 }
 
 func Test_Machine_TaskFunctions(t *testing.T) {

--- a/machine/parser.go
+++ b/machine/parser.go
@@ -7,7 +7,25 @@ import (
 	"io/ioutil"
 
 	"github.com/coinbase/step/machine/state"
+	"github.com/coinbase/step/utils/to"
 )
+
+var TaskFnFmt = "_%v_"
+
+func TaskFnName(name string) string {
+	return fmt.Sprintf(TaskFnFmt, name)
+}
+
+var TaskFnPassFmt = `{
+  "Type": "Pass",
+  "Result": "%v",
+  "ResultPath": "$.Task",
+	"Next": "%v"
+}`
+
+func taskFnPass(name string) string {
+	return fmt.Sprintf(TaskFnPassFmt, name, TaskFnName(name))
+}
 
 // Takes a file, and a map of Task Function s
 func ParseFile(file string) (*StateMachine, error) {
@@ -73,62 +91,93 @@ type stateType struct {
 
 func unmarshallStates(sm *StateMachine, initStates map[string]*json.RawMessage) error {
 	for name, raw_json := range initStates {
-		var err error
-
-		// extract type (safer than regex)
-		var state_type stateType
-		if err = json.Unmarshal(*raw_json, &state_type); err != nil {
-			return err
-		}
-
-		var newState state.State
-
-		switch state_type.Type {
-		case "Pass":
-			var s state.PassState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		case "Task":
-			var s state.TaskState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		case "Choice":
-			var s state.ChoiceState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		case "Wait":
-			var s state.WaitState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		case "Succeed":
-			var s state.SucceedState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		case "Fail":
-			var s state.FailState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		case "Parallel":
-			var s state.ParallelState
-			err = json.Unmarshal(*raw_json, &s)
-			newState = &s
-		default:
-			err = fmt.Errorf("Unknown State %q", state_type.Type)
-		}
-
-		// End of loop return error
+		states, err := unmarshallState(name, raw_json)
 		if err != nil {
 			return err
 		}
-
-		// Set Name and Defaults
-		newName := name
-		newState.SetName(&newName) // Require New Variable Pointer
-
-		if err := sm.AddState(newState); err != nil {
-			return err
+		for _, state := range states {
+			if err := sm.AddState(state); err != nil {
+				return err
+			}
 		}
 	}
 
 	return nil
+}
+
+func unmarshallState(name string, raw_json *json.RawMessage) ([]state.State, error) {
+	var err error
+
+	// extract type (safer than regex)
+	var state_type stateType
+	if err = json.Unmarshal(*raw_json, &state_type); err != nil {
+		return nil, err
+	}
+
+	var newState state.State
+
+	switch state_type.Type {
+	case "Pass":
+		var s state.PassState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "Task":
+		var s state.TaskState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "Choice":
+		var s state.ChoiceState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "Wait":
+		var s state.WaitState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "Succeed":
+		var s state.SucceedState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "Fail":
+		var s state.FailState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "Parallel":
+		var s state.ParallelState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
+	case "TaskFn":
+		// This is a custom state that expands to a TaskFn
+		task_name := TaskFnName(name)
+		pass_json := json.RawMessage(taskFnPass(name))
+
+		pass_fns, err := unmarshallState(name, &pass_json)
+		if err != nil {
+			return nil, err
+		}
+
+		var task_fn state.TaskState
+		err = json.Unmarshal(*raw_json, &task_fn)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set Name and Defaults
+		task_fn.Type = to.Strp("Task")
+		task_fn.SetName(&task_name)
+
+		return append(pass_fns, &task_fn), nil
+	default:
+		err = fmt.Errorf("Unknown State %q", state_type.Type)
+	}
+
+	// End of loop return error
+	if err != nil {
+		return nil, err
+	}
+
+	// Set Name and Defaults
+	newName := name
+	newState.SetName(&newName) // Require New Variable Pointer
+
+	return []state.State{newState}, nil
 }

--- a/utils/errors/errors.go
+++ b/utils/errors/errors.go
@@ -1,0 +1,62 @@
+// errors has a list of common errors and error functions
+package errors
+
+import (
+	"fmt"
+)
+
+//
+// General Errors that represent levels of action to be taken
+//
+
+type AlertError struct {
+	Cause string
+}
+
+func (e AlertError) Error() string {
+	return fmt.Sprintf("AlertError: %v", e.Cause)
+}
+
+type NotifyError struct {
+	Cause string
+}
+
+func (e NotifyError) Error() string {
+	return fmt.Sprintf("NotifyError: %v", e.Cause)
+}
+
+type LogError struct {
+	Cause string
+}
+
+func (e LogError) Error() string {
+	return fmt.Sprintf("LogError: %v", e.Cause)
+}
+
+//
+// Specific Deploy/Release errors
+//
+
+type BadReleaseError struct {
+	Cause string
+}
+
+func (e BadReleaseError) Error() string {
+	return fmt.Sprintf("BadReleaseError: %v", e.Cause)
+}
+
+type LockExistsError struct {
+	Cause string
+}
+
+func (e LockExistsError) Error() string {
+	return fmt.Sprintf("LockExistsError: %v", e.Cause)
+}
+
+type LockError struct {
+	Cause string
+}
+
+func (e LockError) Error() string {
+	return fmt.Sprintf("LockError: %v", e.Cause)
+}


### PR DESCRIPTION
Having a common set of errors to alert on will make it easier to build tools that observer, monitor and alert on Step functions.

`TaskFn` combines the common pattern of having a Pass state before a Task, this will make defining a state machine less annoying.