### PR TITLE
[Fix] Handling States.ALL errors

### DIFF
--- a/deployer/machine.go
+++ b/deployer/machine.go
@@ -19,7 +19,7 @@ func StateMachine() (*machine.StateMachine, error) {
         "Catch": [
           {
             "Comment": "Bad Release or Error GoTo end",
-            "ErrorEquals": ["BadReleaseError", "UnmarshalError", "PanicError"],
+            "ErrorEquals": ["States.ALL"],
             "ResultPath": "$.error",
             "Next": "FailureClean"
           }
@@ -38,7 +38,7 @@ func StateMachine() (*machine.StateMachine, error) {
           },
           {
             "Comment": "Try Release Lock Then Fail",
-            "ErrorEquals": ["LockError", "PanicError"],
+            "ErrorEquals": ["States.ALL"],
             "ResultPath": "$.error",
             "Next": "ReleaseLockFailure"
           }
@@ -51,7 +51,7 @@ func StateMachine() (*machine.StateMachine, error) {
         "Catch": [
           {
             "Comment": "Try Release Lock Then Fail",
-            "ErrorEquals": ["BadReleaseError", "PanicError"],
+            "ErrorEquals": ["States.ALL"],
             "ResultPath": "$.error",
             "Next": "ReleaseLockFailure"
           }
@@ -70,7 +70,7 @@ func StateMachine() (*machine.StateMachine, error) {
           },
           {
             "Comment": "Unsure of State, Leave Lock and Fail",
-            "ErrorEquals": ["DeployLambdaError", "PanicError"],
+            "ErrorEquals": ["States.ALL"],
             "ResultPath": "$.error",
             "Next": "FailureDirty"
           }
@@ -82,12 +82,12 @@ func StateMachine() (*machine.StateMachine, error) {
         "Next": "FailureClean",
         "Retry": [ {
           "Comment": "Keep trying to Release",
-          "ErrorEquals": ["LockError"],
+          "ErrorEquals": ["States.ALL"],
           "MaxAttempts": 3,
           "IntervalSeconds": 30
         }],
         "Catch": [{
-          "ErrorEquals": ["LockError", "PanicError"],
+          "ErrorEquals": ["States.ALL"],
           "ResultPath": "$.error",
           "Next": "FailureDirty"
         }]

--- a/machine/state/state.go
+++ b/machine/state/state.go
@@ -114,10 +114,16 @@ func processRetrier(retryName *string, retriers []*Retrier, exec Execution) Exec
 				retrier.MaxAttempts = to.Intp(3)
 			}
 
-			if errorIncluded(retrier.ErrorEquals, err) && retrier.attempts < *retrier.MaxAttempts {
-				retrier.attempts++
-				// Returns the name of the state to the state-machine to re-execute
-				return input, retryName, nil
+			// Match on first retrier
+			if errorIncluded(retrier.ErrorEquals, err) {
+				if retrier.attempts < *retrier.MaxAttempts {
+					retrier.attempts++
+					// Returns the name of the state to the state-machine to re-execute
+					return input, retryName, nil
+				} else {
+					// Finished retrying so continue
+					return output, next, err
+				}
 			}
 		}
 

--- a/machine/state/state.go
+++ b/machine/state/state.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/coinbase/step/jsonpath"
 	"github.com/coinbase/step/utils/is"
@@ -65,10 +66,11 @@ func errorIncluded(errorEquals []*string, err error) bool {
 	error_type := to.ErrorType(err)
 
 	for _, et := range errorEquals {
-		if *et == error_type {
+		if *et == "States.ALL" || *et == error_type {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -243,21 +245,69 @@ func ValidateNameAndType(s State) error {
 	return nil
 }
 
-func retrierValid(r *Retrier) error {
-	if r.ErrorEquals == nil || len(r.ErrorEquals) == 0 {
-		return fmt.Errorf("Retrier requires ErrorEquals")
+func retryValid(retry []*Retrier) error {
+	if retry == nil {
+		return nil
+	}
+
+	for i, r := range retry {
+		if err := errorEqualsValid(r.ErrorEquals, len(retry)-1 == i); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func catcherValid(c *Catcher) error {
-	if c.ErrorEquals == nil || len(c.ErrorEquals) == 0 {
-		return fmt.Errorf("Catcher requires ErrorEquals")
+func catchValid(catch []*Catcher) error {
+	if catch == nil {
+		return nil
 	}
 
-	if is.EmptyStr(c.Next) {
-		return fmt.Errorf("Catcher requires Next")
+	for i, c := range catch {
+		if err := errorEqualsValid(c.ErrorEquals, len(catch)-1 == i); err != nil {
+			return err
+		}
+
+		if is.EmptyStr(c.Next) {
+			return fmt.Errorf("Catcher requires Next")
+		}
 	}
+	return nil
+}
+
+func errorEqualsValid(errorEquals []*string, last bool) error {
+	if errorEquals == nil || len(errorEquals) == 0 {
+		return fmt.Errorf("Retrier requires ErrorEquals")
+	}
+
+	for _, e := range errorEquals {
+		// If it is a States. Error, then must match one of the defined values
+		if strings.HasPrefix(*e, "States.") {
+			switch *e {
+			case
+				"States.ALL",
+				"States.Timeout",
+				"States.TaskFailed",
+				"States.Permissions",
+				"States.ResultPathMatchFailure",
+				"States.BranchFailed",
+				"States.NoChoiceMatched":
+			default:
+				return fmt.Errorf("Unknown States.* error found %q", *e)
+			}
+		}
+
+		if *e == "States.ALL" {
+			if len(errorEquals) != 1 {
+				return fmt.Errorf(`"States.ALL" ErrorEquals must be only element in list`)
+			}
+
+			if !last {
+				return fmt.Errorf(`"States.ALL" must be last Catcher/Retrier`)
+			}
+		}
+	}
+
 	return nil
 }

--- a/machine/state/task_state.go
+++ b/machine/state/task_state.go
@@ -88,20 +88,12 @@ func (s *TaskState) Validate() error {
 		}
 	}
 
-	if s.Catch != nil {
-		for _, c := range s.Catch {
-			if err := catcherValid(c); err != nil {
-				return err
-			}
-		}
+	if err := catchValid(s.Catch); err != nil {
+		return err
 	}
 
-	if s.Retry != nil {
-		for _, r := range s.Retry {
-			if err := retrierValid(r); err != nil {
-				return err
-			}
-		}
+	if err := retryValid(s.Retry); err != nil {
+		return err
 	}
 
 	return nil

--- a/machine/state/task_state_test.go
+++ b/machine/state/task_state_test.go
@@ -205,3 +205,33 @@ func Test_TaskState_Catch_AND_Retry_StateAll(t *testing.T) {
 
 	assert.Equal(t, 2, *calls)
 }
+
+func Test_TaskState_Catch_AND_Dont_Retry(t *testing.T) {
+	th, calls := countCalls(ThrowTestErrorHandler)
+
+	state := parseValidTaskState([]byte(`{
+		"Next": "Pass",
+		"Retry": [{
+			"ErrorEquals": ["TestError"],
+			"MaxAttempts": 1
+		},{
+			"ErrorEquals": ["States.ALL"]
+		}],
+		"Catch": [{
+			"ErrorEquals": ["States.ALL"],
+			"Next": "Fail"
+		}]
+	}`), th, t)
+
+	testState(state, stateTestData{
+		Input: map[string]interface{}{"a": "c"},
+		Next:  state.Name(),
+	}, t)
+
+	testState(state, stateTestData{
+		Input: map[string]interface{}{"a": "c"},
+		Next:  to.Strp("Fail"),
+	}, t)
+
+	assert.Equal(t, 2, *calls)
+}


### PR DESCRIPTION
This allows the Step Function simulate the `States.ALL` error and adds the validations to make sure it is being used correctly in and Step machine.