### PR TITLE
Increase the max execution history to match AWS limits

### DIFF
--- a/machine/machine.go
+++ b/machine/machine.go
@@ -207,7 +207,7 @@ func (sm *StateMachine) stateLoop(exec *Execution, next *string, input interface
 			return nil, fmt.Errorf("Unknown State: %v", *next)
 		}
 
-		if len(exec.ExecutionHistory) > 250 {
+		if len(exec.ExecutionHistory) > 25000 {
 			return nil, fmt.Errorf("State Overflow")
 		}
 


### PR DESCRIPTION
This increases the max execution history to match the hard limit supported by
step functions within AWS. This is documented as 25,000.

https://docs.aws.amazon.com/step-functions/latest/dg/bp-history-limit.html

250 was limited for some longer running functions, where some were approaching >30 mins in a successful run and would come very close to the 250 limit. A few
cases where it was slower then usual, this condition had tripped it up.