### PR TITLE
[Feature] Allow default handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/coinbase/step
 
 require (
-	github.com/aws/aws-lambda-go v1.8.0
-	github.com/aws/aws-sdk-go v1.16.3
-	github.com/davecgh/go-spew v1.1.1
+	github.com/aws/aws-lambda-go v1.11.1
+	github.com/aws/aws-sdk-go v1.20.2
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
-	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
-	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.2.2
+	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,8 @@
-github.com/aws/aws-lambda-go v1.8.0 h1:YMCzi9FP7MNVVj9AkGpYyaqh/mvFOjhqiDtnNlWtKTg=
-github.com/aws/aws-lambda-go v1.8.0/go.mod h1:zUsUQhAUjYzR8AuduJPCfhBuKWUaDbQiPOG+ouzmE1A=
-github.com/aws/aws-sdk-go v1.16.3 h1:esEQzoR8SVXtwg42nRoR/YLftI4ktsZg6Qwr7jnDXy8=
-github.com/aws/aws-sdk-go v1.16.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-lambda-go v1.11.1 h1:wuOnhS5aqzPOWns71FO35PtbtBKHr4MYsPVt5qXLSfI=
+github.com/aws/aws-lambda-go v1.11.1/go.mod h1:Rr2SMTLeSMKgD45uep9V/NP8tnbCcySgu04cx0k/6cw=
+github.com/aws/aws-sdk-go v1.20.2 h1:/BBeW8F4PPmvJ5jpFvgkCK4RJQXErNndVRnNhO2qEkQ=
+github.com/aws/aws-sdk-go v1.20.2/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=
@@ -10,5 +11,13 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5i
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowKpJ8y4AmooUzdBSR9GU=
+golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -94,6 +94,9 @@ func (sm *StateMachine) SetTaskFnHandlers(tfs *handler.TaskHandlers) error {
 	}
 
 	for name, _ := range *tfs {
+		if name == "" {
+			continue // Skip default Handler
+		}
 		if err := sm.SetTaskHandler(name, taskHandlers); err != nil {
 			return err
 		}

--- a/utils/to/arn.go
+++ b/utils/to/arn.go
@@ -53,17 +53,21 @@ func ArnPath(arn string) string {
 	}
 }
 
-func AwsRegionAccountFromContext(ctx context.Context) (*string, *string) {
+func LambdaArnFromContext(ctx context.Context) (string, error) {
 	lc, ok := lambdacontext.FromContext(ctx)
-	if !ok {
+	if !ok || lc == nil {
+		return "", fmt.Errorf("Incorrect Lambda Context")
+	}
+
+	return lc.InvokedFunctionArn, nil
+}
+
+func AwsRegionAccountFromContext(ctx context.Context) (*string, *string) {
+	arn, err := LambdaArnFromContext(ctx)
+	if err != nil {
 		return nil, nil
 	}
 
-	if lc == nil {
-		return nil, nil
-	}
-
-	arn := lc.InvokedFunctionArn
 	region, account, _ := ArnRegionAccountResource(arn)
 	return &region, &account
 }


### PR DESCRIPTION
This PR allows a Lambda to define a DefaultHandler using the task name `""`. This handler will be called if any incoming event does not have a `Task` property. This is useful for letting the lambda also handle other types of events like SNS, or cloudformation

It also adds the function `LambdaArnFromContext`  to the `to` package.