### PR TITLE
[Feature/Refacotr] breaking change! adding a release lock to stop replays and metadata

### DIFF
--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -37,6 +37,9 @@ type Release struct {
 
 	Timeout *int `json:"timeout,omitempty"` // How long should we try and deploy in seconds
 
+	// Additional Metadata attached but should not be functional
+	Metadata map[string]string `json:"metadata,omitempty"`
+
 	Error   *ReleaseError `json:"error,omitempty"`
 	Success *bool         `json:"success,omitempty"`
 }
@@ -92,9 +95,10 @@ func (r *Release) Validate(s3c aws.S3API, cRelease interface{}) error {
 		return fmt.Errorf("CreatedAt must be defined")
 	}
 
-	// Created at date must be after 5 mins ago, and before 2 mins from now (wiggle room)
-	if !is.WithinTimeFrame(r.CreatedAt, 300*time.Second, 120*time.Second) {
-		return fmt.Errorf("Created at older than 5 mins (or in the future)")
+	// Created at date must be after 5 mins ago, and before 10 days from now
+	// This allows roll backs but protects against replays after a while
+	if !is.WithinTimeFrame(r.CreatedAt, 300*time.Minute, 10*24*time.Hour) {
+		return fmt.Errorf("Created at older than 10 days (or in the future)")
 	}
 
 	if err := r.validateReleaseSHA(s3c, cRelease); err != nil {
@@ -210,14 +214,34 @@ func (r *Release) TimedOut() error {
 // Lock
 ///////
 
-// ReleaseLock deletes the Lock File for the release
-func (r *Release) ReleaseLock(s3c aws.S3API) error {
-	return s3.ReleaseLock(s3c, r.Bucket, r.LockPath(), *r.UUID)
+// UnlockRootLock deletes the Lock File for the release
+func (r *Release) UnlockRoot(s3c aws.S3API) error {
+	return s3.ReleaseLock(s3c, r.Bucket, r.RootLockPath(), *r.UUID)
 }
 
-// GrabLock retrieves the Lock returns LockExistsError, or LockExistsError
-func (r *Release) GrabLock(s3c aws.S3API) error {
-	grabbed, err := s3.GrabLock(s3c, r.Bucket, r.LockPath(), *r.UUID)
+// GrabLock retrieves the Lock returns LockExistsError, or LockError
+func (r *Release) GrabLocks(s3c aws.S3API) error {
+	if err := r.GrabReleaseLock(s3c); err != nil {
+		return err
+	}
+
+	if err := r.GrabRootLock(s3c); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (r *Release) GrabRootLock(s3c aws.S3API) error {
+	return r.grabLock(s3c, *r.RootLockPath())
+}
+
+func (r *Release) GrabReleaseLock(s3c aws.S3API) error {
+	return r.grabLock(s3c, *r.ReleaseLockPath())
+}
+
+func (r *Release) grabLock(s3c aws.S3API, lockPath string) error {
+	grabbed, err := s3.GrabLock(s3c, r.Bucket, &lockPath, *r.UUID)
 
 	// Check grabbed first because there are errors that can be thrown before anything is created
 	if !grabbed {
@@ -225,7 +249,7 @@ func (r *Release) GrabLock(s3c aws.S3API) error {
 			return &errors.LockExistsError{err.Error()}
 		}
 
-		return &errors.LockExistsError{fmt.Sprintf("Lock Already Exists at %v:%v", *r.Bucket, *r.LockPath())}
+		return &errors.LockExistsError{fmt.Sprintf("Lock Already Exists at %v:%v", *r.Bucket, lockPath)}
 	}
 
 	// Error if MAYBE grabbed the lock and we should try to unlock
@@ -236,7 +260,12 @@ func (r *Release) GrabLock(s3c aws.S3API) error {
 	return nil
 }
 
-func (r *Release) LockPath() *string {
+func (r *Release) ReleaseLockPath() *string {
+	s := fmt.Sprintf("%v/lock", *r.ReleaseDir())
+	return &s
+}
+
+func (r *Release) RootLockPath() *string {
 	s := fmt.Sprintf("%v/lock", *r.RootDir())
 	return &s
 }
@@ -336,6 +365,7 @@ func (release *Release) AppendLog(s3c aws.S3API, log string) error {
 			return err // All other errors return
 		}
 	}
+
 	// doubly sure
 	if logFile == nil {
 		logFile = to.Strp("")

--- a/bifrost/release_halt_test.go
+++ b/bifrost/release_halt_test.go
@@ -17,10 +17,10 @@ func Test_IsHalt_ReleaseTimeout(t *testing.T) {
 	assert.Error(t, r.IsHalt(awsc.S3))
 
 	// 10 second halt
-	r.CreatedAt = to.Timep(time.Now().Add(-1 * (9 * time.Second)))
+	r.StartedAt = to.Timep(time.Now().Add(-1 * (9 * time.Second)))
 	r.Timeout = to.Intp(10)
 	assert.NoError(t, r.IsHalt(awsc.S3))
-	r.CreatedAt = to.Timep(time.Now().Add(-1 * (11 * time.Second)))
+	r.StartedAt = to.Timep(time.Now().Add(-1 * (11 * time.Second)))
 	assert.Error(t, r.IsHalt(awsc.S3))
 }
 

--- a/bifrost/release_lock_test.go
+++ b/bifrost/release_lock_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_Lock_GrabRelease(t *testing.T) {
+func Test_Lock_GrabRootLock(t *testing.T) {
 	r := MockRelease()
 
 	r2 := MockRelease()
@@ -16,11 +16,11 @@ func Test_Lock_GrabRelease(t *testing.T) {
 	awsc := MockAwsClients(r)
 	s3c := awsc.S3Client(nil, nil, nil)
 
-	assert.NoError(t, r.GrabLock(s3c))
-	assert.NoError(t, r.GrabLock(s3c))
-	assert.Error(t, r2.GrabLock(s3c))
+	assert.NoError(t, r.GrabRootLock(s3c))
+	assert.NoError(t, r.GrabRootLock(s3c))
+	assert.Error(t, r2.GrabRootLock(s3c))
 
-	assert.NoError(t, r.ReleaseLock(s3c))
-	assert.NoError(t, r.ReleaseLock(s3c))
-	assert.NoError(t, r2.GrabLock(s3c))
+	assert.NoError(t, r.UnlockRoot(s3c))
+	assert.NoError(t, r.UnlockRoot(s3c))
+	assert.NoError(t, r2.GrabRootLock(s3c))
 }

--- a/bifrost/release_test.go
+++ b/bifrost/release_test.go
@@ -45,7 +45,8 @@ func TestReleasePaths(t *testing.T) {
 	assert.Equal(t, "account/project/config/id", *release.ReleaseDir())
 	assert.Equal(t, "account/project/config/id/release", *release.ReleasePath())
 	assert.Equal(t, "account/project/config/id/log", *release.LogPath())
-	assert.Equal(t, "account/project/config/lock", *release.LockPath())
+	assert.Equal(t, "account/project/config/lock", *release.RootLockPath())
+	assert.Equal(t, "account/project/config/id/lock", *release.ReleaseLockPath())
 	assert.Equal(t, "account/project/_shared", *release.SharedProjectDir())
 }
 

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -45,8 +45,7 @@ func ValidateHandler(awsc aws.AwsClients) interface{} {
 	return func(ctx context.Context, release *Release) (*Release, error) {
 		// Override any attributes set by the client
 		release.ReleaseSHA256 = to.SHA256Struct(release)
-		release.UUID = nil // Will be set later
-		release.Success = to.Boolp(false)
+		release.WipeControlledValues()
 
 		region, account := to.AwsRegionAccountFromContext(ctx)
 		release.SetDefaults(region, account, "coinbase-step-deployer-")

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -63,7 +63,7 @@ func ValidateHandler(awsc aws.AwsClients) interface{} {
 func LockHandler(awsc aws.AwsClients) interface{} {
 	return func(ctx context.Context, release *Release) (*Release, error) {
 		// returns LockExistsError, LockError
-		return release, release.GrabLock(awsc.S3Client(nil, nil, nil))
+		return release, release.GrabLocks(awsc.S3Client(nil, nil, nil))
 	}
 }
 
@@ -91,7 +91,7 @@ func DeployHandler(awsc aws.AwsClients) interface{} {
 		}
 
 		release.Success = to.Boolp(true)
-		release.ReleaseLock(awsc.S3Client(nil, nil, nil))
+		release.UnlockRoot(awsc.S3Client(nil, nil, nil))
 
 		return release, nil
 	}
@@ -100,7 +100,7 @@ func DeployHandler(awsc aws.AwsClients) interface{} {
 func ReleaseLockFailureHandler(awsc aws.AwsClients) interface{} {
 	return func(ctx context.Context, release *Release) (*Release, error) {
 
-		if err := release.ReleaseLock(awsc.S3Client(nil, nil, nil)); err != nil {
+		if err := release.UnlockRoot(awsc.S3Client(nil, nil, nil)); err != nil {
 			return nil, errors.LockError{err.Error()}
 		}
 

--- a/deployer/helpers_test.go
+++ b/deployer/helpers_test.go
@@ -29,6 +29,7 @@ func MockRelease() *Release {
 			ProjectName:  to.Strp("project"),
 			ConfigName:   to.Strp("development"),
 			CreatedAt:    to.Timep(time.Now()),
+			Metadata:     map[string]string{"User": "User@user.com"},
 		},
 		LambdaName:       to.Strp("lambdaname"),
 		StepFnName:       to.Strp("stepfnname"),
@@ -82,8 +83,23 @@ func createTestStateMachine(t *testing.T, awsc *mocks.MockClients) *machine.Stat
 	return stateMachine
 }
 
-func assertNoLock(t *testing.T, awsc aws.AwsClients, release *Release) {
-	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.LockPath())
+func assertNoRootLock(t *testing.T, awsc aws.AwsClients, release *Release) {
+	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.RootLockPath())
+	assert.Error(t, err) // Not found error
+	assert.IsType(t, &s3.NotFoundError{}, err)
+}
+
+func assertNoRootLockWithReleseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
+	assertNoRootLock(t, awsc, release)
+
+	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleaseLockPath())
+	assert.NoError(t, err) // Not error
+}
+
+func assertNoRootLockNoReleseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
+	assertNoRootLock(t, awsc, release)
+
+	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleaseLockPath())
 	assert.Error(t, err) // Not found error
 	assert.IsType(t, &s3.NotFoundError{}, err)
 }

--- a/deployer/integration_test.go
+++ b/deployer/integration_test.go
@@ -27,7 +27,7 @@ func Test_DeployHandler_Execution_Works(t *testing.T) {
 	assert.Equal(t, output["success"], true)
 	assert.NotRegexp(t, "error", exec.LastOutputJSON)
 
-	assertNoLock(t, awsc, release)
+	assertNoRootLockWithReleseLock(t, awsc, release)
 	assert.Equal(t, []string{
 		"Validate",
 		"Lock",
@@ -67,7 +67,7 @@ func Test_DeployHandler_Execution_Errors_BadInput(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLockNoReleseLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -85,7 +85,7 @@ func Test_DeployHandler_Execution_UnmarhsallError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "UnmarshalError", exec.LastOutputJSON)
 	assert.Regexp(t, "asd", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLockNoReleseLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -106,7 +106,7 @@ func Test_DeployHandler_Execution_Errors_Release(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "ReleaseID must", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -116,7 +116,7 @@ func Test_DeployHandler_Execution_Errors_Release(t *testing.T) {
 
 func Test_DeployHandler_Execution_Errors_CreatedAt(t *testing.T) {
 	release := MockRelease()
-	release.CreatedAt = to.Timep(time.Now().Add(10 * time.Minute))
+	release.CreatedAt = to.Timep(time.Now().Add(300 * time.Hour))
 
 	awsc := MockAwsClients(release)
 
@@ -127,7 +127,7 @@ func Test_DeployHandler_Execution_Errors_CreatedAt(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "older", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLockNoReleseLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -135,13 +135,13 @@ func Test_DeployHandler_Execution_Errors_CreatedAt(t *testing.T) {
 	}, exec.Path())
 }
 
-func Test_DeployHandler_Execution_Errors_LockError(t *testing.T) {
+func Test_DeployHandler_Execution_Errors_Root_LockError(t *testing.T) {
 	release := MockRelease()
 	awsc := MockAwsClients(release)
 
 	state_machine := createTestStateMachine(t, awsc)
 
-	awsc.S3.AddPutObject(*release.LockPath(), fmt.Errorf("PuttyError"))
+	awsc.S3.AddPutObject(*release.RootLockPath(), fmt.Errorf("PuttyError"))
 
 	exec, err := state_machine.Execute(release)
 
@@ -149,7 +149,7 @@ func Test_DeployHandler_Execution_Errors_LockError(t *testing.T) {
 	assert.Regexp(t, "LockError", exec.LastOutputJSON)
 	assert.Regexp(t, "PuttyError", exec.LastOutputJSON)
 
-	assertNoLock(t, awsc, release)
+	assertNoRootLockWithReleseLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -165,7 +165,31 @@ func Test_DeployHandler_Execution_Errors_LockExistsError(t *testing.T) {
 
 	state_machine := createTestStateMachine(t, awsc)
 
-	awsc.S3.AddGetObject(*release.LockPath(), `{"uuid":"notuuid"}`, nil)
+	awsc.S3.AddGetObject(*release.RootLockPath(), `{"uuid":"notuuid"}`, nil)
+
+	exec, err := state_machine.Execute(release)
+
+	assert.Error(t, err)
+	assert.Regexp(t, "LockExistsError", exec.LastOutputJSON)
+	assert.Regexp(t, "Lock Already Exists", exec.LastOutputJSON)
+
+	assert.Equal(t, []string{
+		"Validate",
+		"Lock",
+		"FailureClean",
+	}, exec.Path())
+}
+
+func Test_DeployHandler_Execution_Errors_Release_LockError(t *testing.T) {
+	release := MockRelease()
+	awsc := MockAwsClients(release)
+
+	state_machine := createTestStateMachine(t, awsc)
+
+	uidStr := fmt.Sprintf("{\"uuid\":\"%v\"}", *release.ReleaseID)
+	fmt.Println(uidStr)
+
+	awsc.S3.AddGetObject(*release.ReleaseLockPath(), uidStr, nil)
 
 	exec, err := state_machine.Execute(release)
 
@@ -194,7 +218,7 @@ func Test_DeployHandler_Execution_Errors_WrongLambdaTags(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "DeployWith", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLockWithReleseLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -218,7 +242,7 @@ func Test_DeployHandler_Execution_Errors_WrongSFNPath(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "Role Path", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLockWithReleseLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -241,7 +265,7 @@ func Test_DeployHandler_Execution_Errors_BadLambdaSHA(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "Lambda SHA", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -261,7 +285,7 @@ func Test_DeployHandler_Execution_Errors_BadReleasePath(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "uploaded Release struct", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -281,7 +305,7 @@ func Test_DeployHandler_Execution_Errors_WrongReleasePath(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "Release SHA", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",
@@ -301,7 +325,7 @@ func Test_DeployHandler_Execution_Errors_DifferentReleaseSHA(t *testing.T) {
 	assert.Error(t, err)
 	assert.Regexp(t, "BadReleaseError", exec.LastOutputJSON)
 	assert.Regexp(t, "Release SHA", exec.LastOutputJSON)
-	assertNoLock(t, awsc, release)
+	assertNoRootLock(t, awsc, release)
 
 	assert.Equal(t, []string{
 		"Validate",


### PR DESCRIPTION
Previously we stopped replaying the same release using a timestamp and not running the same deploy unless it is less than 5 mins old. Build a new release can take time. When an issue occurs and we want to quickly roll back to a previous release an admin should be able to quickly re-release a previous deploy without much effort.

This PR adds a lock in the release directory that stops the same release being run twice. By deleting this lock you can now redeploy the same release as long as that was within 10 days. Since deleting keys from the s3 bucket is an admin level permission, this can only be done by admins.

This PR also:
1. allows arbitrary metadata to be attached to the release, as a means of recording non-functional information about a release e.g. git commit, user, other times stamps.
2. adds `started_at` field so that we can Halt on that rather than a potentially 10 day old `created_at` date.