### PR TITLE
Support setting CacheControl

### DIFF
--- a/aws/s3/s3.go
+++ b/aws/s3/s3.go
@@ -133,6 +133,35 @@ func PutWithType(s3c aws.S3API, bucket *string, path *string, content *[]byte, c
 	})
 }
 
+func PutWithCacheControl(s3c aws.S3API, bucket *string, path *string, content *[]byte, cacheControl *string) error {
+	if content == nil {
+		return fmt.Errorf("Put content is nil")
+	}
+
+	return put(s3c, &s3.PutObjectInput{
+		Bucket:       bucket,
+		Key:          path,
+		Body:         bytes.NewReader(*content),
+		ACL:          to.Strp("private"),
+		CacheControl: cacheControl,
+	})
+}
+
+func PutWithTypeAndCacheControl(s3c aws.S3API, bucket *string, path *string, content *[]byte, contentType *string, cacheControl *string) error {
+	if content == nil {
+		return fmt.Errorf("Put content is nil")
+	}
+
+	return put(s3c, &s3.PutObjectInput{
+		Bucket:       bucket,
+		Key:          path,
+		Body:         bytes.NewReader(*content),
+		ACL:          to.Strp("private"),
+		ContentType: contentType,
+		CacheControl: cacheControl,
+	})
+}
+
 func PutStr(s3c aws.S3API, bucket *string, path *string, content *string) error {
 	if content == nil {
 		return fmt.Errorf("PutStr content is nil")

--- a/aws/s3/s3_test.go
+++ b/aws/s3/s3_test.go
@@ -47,6 +47,38 @@ func Test_Put_With_Type_Success(t *testing.T) {
 	assert.Equal(t, "text/html", string(*object.ContentType))
 }
 
+func Test_Put_With_Cache_Control_Success(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	key := to.Strp("/path")
+	content := []byte("asdji")
+	cacheControl := to.Strp("public, max-age=31556926")
+	err := PutWithCacheControl(s3c, bucket, key, &content, cacheControl)
+	assert.NoError(t, err)
+
+	object, out, err := GetObject(s3c, bucket, key)
+	assert.NoError(t, err)
+	assert.Equal(t, "asdji", string(*out))
+	assert.Equal(t, "public, max-age=31556926", string(*object.CacheControl))
+}
+
+func Test_Put_With_Type_And_Cache_Control_Success(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	key := to.Strp("/path")
+	content := []byte("<html></html>")
+	contentType := to.Strp("text/html")
+	cacheControl := to.Strp("public, max-age=31556926")
+	err := PutWithTypeAndCacheControl(s3c, bucket, key, &content, contentType, cacheControl)
+	assert.NoError(t, err)
+
+	object, out, err := GetObject(s3c, bucket, key)
+	assert.NoError(t, err)
+	assert.Equal(t, "<html></html>", string(*out))
+	assert.Equal(t, "text/html", string(*object.ContentType))
+	assert.Equal(t, "public, max-age=31556926", string(*object.CacheControl))
+}
+
 func Test_Delete_Success(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")


### PR DESCRIPTION
Add support for setting the `CacheControl` option to S3 PutObject helpers.