### PR TITLE
Add user lock functionality

### DIFF
--- a/aws/s3/lock.go
+++ b/aws/s3/lock.go
@@ -17,7 +17,7 @@ type UserLock struct {
 
 func GrabUserLock(s3c aws.S3API, bucket *string, lock_path *string) (bool, error) {
 	var userLock UserLock
-	err := GetStruct(s3c, bucket, lock_path, userLock)
+	err := GetStruct(s3c, bucket, lock_path, &userLock)
 	if err != nil {
 		switch err.(type) {
 		case *NotFoundError:
@@ -26,7 +26,9 @@ func GrabUserLock(s3c aws.S3API, bucket *string, lock_path *string) (bool, error
 			return false, err // All other errors return
 		}
 	}
-	return true, nil
+	if userLock.User != "" {
+		return false, nil
+	}
 
 	lock := &UserLock{User: "step", LockReason: "deploy is currently running"}
 	err = PutStruct(s3c, bucket, lock_path, lock)

--- a/aws/s3/lock.go
+++ b/aws/s3/lock.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/coinbase/step/aws"
-	"github.com/coinbase/step/errors"
 )
 
 type Lock struct {
@@ -28,12 +27,7 @@ func CheckUserLock(s3c aws.S3API, bucket *string, lock_path *string) error {
 			return err // All other errors return
 		}
 	}
-	// if struct is not empty, then user-lock exists
-	if userLock != (UserLock{}) {
-		return &errors.LockExistsError{fmt.Sprintf("Deploys locked by %v for reason: %v", userLock.User, userLock.LockReason)}
-	}
-
-	return nil
+	return fmt.Errorf("Deploys locked by %v for reason: %v", userLock.User, userLock.LockReason)
 }
 
 // GrabLock creates a lock file in S3 with a UUID

--- a/aws/s3/lock.go
+++ b/aws/s3/lock.go
@@ -23,11 +23,13 @@ func CheckUserLock(s3c aws.S3API, bucket *string, lock_path *string) error {
 		switch err.(type) {
 		case *NotFoundError:
 			// good we want this
+			return nil
 		default:
 			return err // All other errors return
 		}
 	}
-	if userLock.User != "" {
+	// if struct is not empty, then user-lock exists
+	if userLock != (UserLock{}) {
 		return &errors.LockExistsError{fmt.Sprintf("Deploys locked by %v for reason: %v", userLock.User, userLock.LockReason)}
 	}
 

--- a/aws/s3/lock.go
+++ b/aws/s3/lock.go
@@ -27,6 +27,9 @@ func CheckUserLock(s3c aws.S3API, bucket *string, lock_path *string) error {
 			return err // All other errors return
 		}
 	}
+	if userLock == (UserLock{}) {
+		return nil
+	}
 	return fmt.Errorf("Deploys locked by %v for reason: %v", userLock.User, userLock.LockReason)
 }
 

--- a/aws/s3/lock_test.go
+++ b/aws/s3/lock_test.go
@@ -20,12 +20,12 @@ func Test_GrabLock_Success(t *testing.T) {
 	assert.True(t, grabbed)
 }
 
-func Test_GrabUserLock_Success(t *testing.T) {
+func Test_CheckUserLock_Success(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")
 	path := to.Strp("path")
 
-	grabbed, err := GrabUserLock(s3c, bucket, path)
+	grabbed, _, err := CheckUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
 	assert.True(t, grabbed)
@@ -54,13 +54,13 @@ func Test_GrabLock_Failure_Already_Locked(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, grabbed)
 }
-func Test_GrabUserLock_Failure_Already_Locked(t *testing.T) {
+func Test_CheckUserLock_Failure_Already_Locked(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")
 	path := to.Strp("path")
 
 	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "testing"}`, nil)
-	grabbed, err := GrabUserLock(s3c, bucket, path)
+	grabbed, _, err := CheckUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
 	assert.False(t, grabbed)
@@ -78,13 +78,13 @@ func Test_GrabLock_Failure_S3_Get_Error(t *testing.T) {
 	assert.False(t, grabbed)
 }
 
-func Test_GrabUserLock_Failure_S3_Get_Error(t *testing.T) {
+func Test_CheckUserLock_Failure_S3_Get_Error(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")
 	path := to.Strp("path")
 
 	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "hello"}`, fmt.Errorf("ERRRR"))
-	grabbed, err := GrabUserLock(s3c, bucket, path)
+	grabbed, _, err := CheckUserLock(s3c, bucket, path)
 
 	assert.Error(t, err)
 	assert.False(t, grabbed)
@@ -102,33 +102,12 @@ func Test_GrabLock_Failure_S3_Upload_Error(t *testing.T) {
 	assert.True(t, grabbed)
 }
 
-func Test_GrabUserLock_Failure_S3_Upload_Error(t *testing.T) {
-	s3c := &mocks.MockS3Client{}
-	bucket := to.Strp("bucket")
-	path := to.Strp("path")
-
-	s3c.AddPutObject(*path, fmt.Errorf("ERRRR"))
-	grabbed, err := GrabUserLock(s3c, bucket, path)
-
-	assert.Error(t, err)
-	assert.True(t, grabbed)
-}
-
 func Test_ReleaseLock_Success_No_Object(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")
 	path := to.Strp("path")
 
 	err := ReleaseLock(s3c, bucket, path, "UUID")
-
-	assert.NoError(t, err)
-}
-func Test_ReleaseUserLock_Success_No_Object(t *testing.T) {
-	s3c := &mocks.MockS3Client{}
-	bucket := to.Strp("bucket")
-	path := to.Strp("path")
-
-	err := ReleaseUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
 }
@@ -140,17 +119,6 @@ func Test_ReleaseLock_Success_Correct_Lock(t *testing.T) {
 
 	s3c.AddGetObject(*path, `{"uuid": "UUID"}`, nil)
 	err := ReleaseLock(s3c, bucket, path, "UUID")
-
-	assert.NoError(t, err)
-}
-
-func Test_ReleaseUserLock_Success_Correct_Lock(t *testing.T) {
-	s3c := &mocks.MockS3Client{}
-	bucket := to.Strp("bucket")
-	path := to.Strp("path")
-
-	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "hello"}`, nil)
-	err := ReleaseUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
 }

--- a/aws/s3/lock_test.go
+++ b/aws/s3/lock_test.go
@@ -20,6 +20,17 @@ func Test_GrabLock_Success(t *testing.T) {
 	assert.True(t, grabbed)
 }
 
+func Test_GrabUserLock_Success(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	path := to.Strp("path")
+
+	grabbed, err := GrabUserLock(s3c, bucket, path)
+
+	assert.NoError(t, err)
+	assert.True(t, grabbed)
+}
+
 func Test_GrabLock_Success_Already_Has_Lock(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")
@@ -43,6 +54,17 @@ func Test_GrabLock_Failure_Already_Locked(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, grabbed)
 }
+func Test_GrabUserLock_Failure_Already_Locked(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	path := to.Strp("path")
+
+	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "testing"}`, nil)
+	grabbed, err := GrabUserLock(s3c, bucket, path)
+
+	assert.NoError(t, err)
+	assert.False(t, grabbed)
+}
 
 func Test_GrabLock_Failure_S3_Get_Error(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
@@ -51,6 +73,18 @@ func Test_GrabLock_Failure_S3_Get_Error(t *testing.T) {
 
 	s3c.AddGetObject(*path, `{"uuid": "NOT_UUID"}`, fmt.Errorf("ERRRR"))
 	grabbed, err := GrabLock(s3c, bucket, path, "UUID")
+
+	assert.Error(t, err)
+	assert.False(t, grabbed)
+}
+
+func Test_GrabUserLock_Failure_S3_Get_Error(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	path := to.Strp("path")
+
+	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "hello"}`, fmt.Errorf("ERRRR"))
+	grabbed, err := GrabUserLock(s3c, bucket, path)
 
 	assert.Error(t, err)
 	assert.False(t, grabbed)
@@ -68,12 +102,33 @@ func Test_GrabLock_Failure_S3_Upload_Error(t *testing.T) {
 	assert.True(t, grabbed)
 }
 
+func Test_GrabUserLock_Failure_S3_Upload_Error(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	path := to.Strp("path")
+
+	s3c.AddPutObject(*path, fmt.Errorf("ERRRR"))
+	grabbed, err := GrabUserLock(s3c, bucket, path)
+
+	assert.Error(t, err)
+	assert.True(t, grabbed)
+}
+
 func Test_ReleaseLock_Success_No_Object(t *testing.T) {
 	s3c := &mocks.MockS3Client{}
 	bucket := to.Strp("bucket")
 	path := to.Strp("path")
 
 	err := ReleaseLock(s3c, bucket, path, "UUID")
+
+	assert.NoError(t, err)
+}
+func Test_ReleaseUserLock_Success_No_Object(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	path := to.Strp("path")
+
+	err := ReleaseUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
 }
@@ -85,6 +140,17 @@ func Test_ReleaseLock_Success_Correct_Lock(t *testing.T) {
 
 	s3c.AddGetObject(*path, `{"uuid": "UUID"}`, nil)
 	err := ReleaseLock(s3c, bucket, path, "UUID")
+
+	assert.NoError(t, err)
+}
+
+func Test_ReleaseUserLock_Success_Correct_Lock(t *testing.T) {
+	s3c := &mocks.MockS3Client{}
+	bucket := to.Strp("bucket")
+	path := to.Strp("path")
+
+	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "hello"}`, nil)
+	err := ReleaseUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
 }

--- a/aws/s3/lock_test.go
+++ b/aws/s3/lock_test.go
@@ -25,10 +25,9 @@ func Test_CheckUserLock_Success(t *testing.T) {
 	bucket := to.Strp("bucket")
 	path := to.Strp("path")
 
-	grabbed, _, err := CheckUserLock(s3c, bucket, path)
+	err := CheckUserLock(s3c, bucket, path)
 
 	assert.NoError(t, err)
-	assert.True(t, grabbed)
 }
 
 func Test_GrabLock_Success_Already_Has_Lock(t *testing.T) {
@@ -60,10 +59,8 @@ func Test_CheckUserLock_Failure_Already_Locked(t *testing.T) {
 	path := to.Strp("path")
 
 	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "testing"}`, nil)
-	grabbed, _, err := CheckUserLock(s3c, bucket, path)
-
-	assert.NoError(t, err)
-	assert.False(t, grabbed)
+	err := CheckUserLock(s3c, bucket, path)
+	assert.Error(t, err)
 }
 
 func Test_GrabLock_Failure_S3_Get_Error(t *testing.T) {
@@ -84,10 +81,9 @@ func Test_CheckUserLock_Failure_S3_Get_Error(t *testing.T) {
 	path := to.Strp("path")
 
 	s3c.AddGetObject(*path, `{"user": "test", "lock_reason": "hello"}`, fmt.Errorf("ERRRR"))
-	grabbed, _, err := CheckUserLock(s3c, bucket, path)
+	err := CheckUserLock(s3c, bucket, path)
 
 	assert.Error(t, err)
-	assert.False(t, grabbed)
 }
 
 func Test_GrabLock_Failure_S3_Upload_Error(t *testing.T) {

--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -265,13 +265,8 @@ func (r *Release) GrabReleaseLock(s3c aws.S3API) error {
 	return r.grabLock(s3c, *r.ReleaseLockPath())
 }
 
-func (r *Release) CheckUserLock(s3c aws.S3API) error {
-	return r.checkUserLock(s3c, *r.UserLockPath())
-}
-
-func (r *Release) checkUserLock(s3c aws.S3API, lockPath string) error {
+func (r *Release) CheckUserLock(s3c aws.S3API, lockPath string) error {
 	err := s3.CheckUserLock(s3c, r.Bucket, &lockPath)
-
 	if err != nil {
 		return err
 	}
@@ -309,7 +304,7 @@ func (r *Release) RootLockPath() *string {
 }
 
 func (r *Release) UserLockPath() *string {
-	s := fmt.Sprintf("%v/user-lock", *r.ReleaseDir())
+	s := fmt.Sprintf("%v/user-lock", *r.RootDir())
 	return &s
 }
 

--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -314,7 +314,7 @@ func (r *Release) RootLockPath() *string {
 }
 
 func (r *Release) UserLockPath() *string {
-	s := fmt.Sprintf("%v/user-lock", *r.ReleaseDir())
+	s := fmt.Sprintf("%v/user-lock", *r.RootDir())
 	return &s
 }
 

--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -270,15 +270,10 @@ func (r *Release) CheckUserLock(s3c aws.S3API) error {
 }
 
 func (r *Release) checkUserLock(s3c aws.S3API, lockPath string) error {
-	grabbed, lock, err := s3.CheckUserLock(s3c, r.Bucket, &lockPath)
-	if !grabbed {
-		if err != nil {
-			return &errors.LockExistsError{err.Error()}
-		}
-		return &errors.LockExistsError{fmt.Sprintf("Lock Already Exists at %v:%v. Deploys locked by %v for reason: %v", *r.Bucket, lockPath, lock.User, lock.LockReason)}
-	}
+	err := s3.CheckUserLock(s3c, r.Bucket, &lockPath)
+
 	if err != nil {
-		return &errors.LockError{err.Error()}
+		return err
 	}
 	return nil
 }

--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -250,7 +250,7 @@ func (r *Release) GrabLocks(s3c aws.S3API) error {
 		return err
 	}
 
-	if err := r.CheckUserLock(s3c); err != nil {
+	if err := r.CheckUserLock(s3c, *r.UserLockPath()); err != nil {
 		return err
 	}
 
@@ -268,7 +268,7 @@ func (r *Release) GrabReleaseLock(s3c aws.S3API) error {
 func (r *Release) CheckUserLock(s3c aws.S3API, lockPath string) error {
 	err := s3.CheckUserLock(s3c, r.Bucket, &lockPath)
 	if err != nil {
-		return err
+		return &errors.LockExistsError{err.Error()}
 	}
 	return nil
 }


### PR DESCRIPTION
The user-lock struct is an S3 object that gets written whenever a user manually locks deploys for a given configuration (in the monorepo). 

The step deployers should attempt to grab the lock before each deploy to ensure that:
1. no user can lock deploys to a specific configuration while a deploy is going out
2. no deploys go out when user-lock file already exists