### PR TITLE
Upload releases to the release region instead of deployer region

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -38,7 +38,7 @@ func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_fi
 	}
 
 	err := s3.PutFile(
-		awsc.S3Client(nil, nil, nil),
+		awsc.S3Client(release.AwsRegion, nil, nil),
 		zip_file_path,
 		release.Bucket,
 		release.LambdaZipPath(),
@@ -52,7 +52,7 @@ func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_fi
 	release.CreatedAt = to.Timep(time.Now())
 
 	// Uploading the Release to S3 to match SHAs
-	if err := s3.PutStruct(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleasePath(), release); err != nil {
+	if err := s3.PutStruct(awsc.S3Client(release.AwsRegion, nil, nil), release.Bucket, release.ReleasePath(), release); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Currently we set the region credential to nil which defaults to the
region of the caller - in this case whatever region the deployer
is running in - usually us-east-1 for us.

However for fenrir deployments we need the release binary to be in the
same region as the deployment or cloudflare will fail the deployment

# Testing
Tested by deploying to infra-sandbox1-dev-euw1

type=routine
risk=low
impact=sev5
