### PR TITLE
FEAT - Adding support for Map State in framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ tmp
 coverage.out
 coverage.html
 vendor
+.idea

--- a/examples/map.json
+++ b/examples/map.json
@@ -1,0 +1,24 @@
+{
+  "Comment": "Adds some coordinates to the input",
+  "StartAt": "Start",
+  "States": {
+    "Start": {
+      "Type": "Map",
+      "InputPath": "$.detail",
+      "ItemsPath": "$.shipped",
+      "MaxConcurrency": 0,
+      "Iterator": {
+        "StartAt": "Validate",
+        "States": {
+          "Validate": {
+            "Type": "Task",
+            "Resource": "arn:aws:lambda:us-east-1:123456789012:function:ship-val",
+            "End": true
+          }
+        }
+      },
+      "ResultPath": "$.detail.shipped",
+      "End": true
+    }
+  }
+}

--- a/examples/map.json
+++ b/examples/map.json
@@ -6,6 +6,7 @@
       "Type": "Map",
       "InputPath": "$.detail",
       "ItemsPath": "$.shipped",
+      "ResultPath": "$.detail.shipped",
       "MaxConcurrency": 0,
       "Iterator": {
         "StartAt": "Validate",
@@ -17,7 +18,6 @@
           }
         }
       },
-      "ResultPath": "$.detail.shipped",
       "End": true
     }
   }

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -206,6 +206,25 @@ func (path *Path) Get(input interface{}) (value interface{}, err error) {
 	return recursiveGet(input, path.path)
 }
 
+// GetSlice returns array from Path
+
+func (path *Path) GetSlice(input interface{}) (output []interface{}, err error ) {
+	output_value, err := path.Get(input)
+
+	if err != nil {
+		return nil, fmt.Errorf("GetSlice Error %q", err)
+	}
+
+	switch output_value.(type) {
+	case []interface{}:
+		output = output_value.([]interface{})
+	default:
+		return nil, fmt.Errorf("GetSlice Error: must be an array")
+	}
+
+	return output, nil
+}
+
 // Set sets a Value in a map with Path
 func (path *Path) Set(input interface{}, value interface{}) (output map[string]interface{}, err error) {
 	var set_path []string

--- a/jsonpath/jsonpath_get_test.go
+++ b/jsonpath/jsonpath_get_test.go
@@ -122,3 +122,16 @@ func Test_JSONPath_GetString(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, *out, test)
 }
+
+func Test_JSONPath_GetSplice(t *testing.T) {
+	test := []interface{}{1,2,3}
+	outer := map[string]interface{}{"x": test}
+
+	path, err := NewPath("$.x")
+	assert.NoError(t, err)
+
+	out, err := path.GetSlice(outer)
+	assert.NoError(t, err)
+	assert.Equal(t, out, test)
+
+}

--- a/machine/choice_state.go
+++ b/machine/choice_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/choice_state_test.go
+++ b/machine/choice_state_test.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"testing"

--- a/machine/execution.go
+++ b/machine/execution.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/sfn"
-	"github.com/coinbase/step/machine/state"
 	"github.com/coinbase/step/utils/to"
 )
 
@@ -50,11 +49,11 @@ func (sm *Execution) SetLastOutput(output interface{}, err error) {
 	}
 }
 
-func (sm *Execution) EnteredEvent(s state.State, input interface{}) {
+func (sm *Execution) EnteredEvent(s State, input interface{}) {
 	sm.ExecutionHistory = append(sm.ExecutionHistory, createEnteredEvent(s, input))
 }
 
-func (sm *Execution) ExitedEvent(s state.State, output interface{}) {
+func (sm *Execution) ExitedEvent(s State, output interface{}) {
 	sm.ExecutionHistory = append(sm.ExecutionHistory, createExitedEvent(s, output))
 }
 
@@ -92,7 +91,7 @@ func createEvent(name string) HistoryEvent {
 	}
 }
 
-func createEnteredEvent(state state.State, input interface{}) HistoryEvent {
+func createEnteredEvent(state State, input interface{}) HistoryEvent {
 	event := createEvent(fmt.Sprintf("%vStateEntered", *state.GetType()))
 	json_raw, err := json.Marshal(input)
 
@@ -108,7 +107,7 @@ func createEnteredEvent(state state.State, input interface{}) HistoryEvent {
 	return event
 }
 
-func createExitedEvent(state state.State, output interface{}) HistoryEvent {
+func createExitedEvent(state State, output interface{}) HistoryEvent {
 	event := createEvent(fmt.Sprintf("%vStateExited", *state.GetType()))
 	json_raw, err := json.Marshal(output)
 

--- a/machine/fail_state.go
+++ b/machine/fail_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/machine.go
+++ b/machine/machine.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/aws/aws-lambda-go/lambdacontext"
 	"github.com/coinbase/step/handler"
-	"github.com/coinbase/step/machine/state"
 	"github.com/coinbase/step/utils/is"
 	"github.com/coinbase/step/utils/to"
 )
@@ -27,7 +26,7 @@ var EmptyStateMachine = `{
 // IMPLEMENTATION
 
 // States is the collection of states
-type States map[string]state.State
+type States map[string]State
 
 // StateMachine the core struct for the machine
 type StateMachine struct {
@@ -52,7 +51,7 @@ func Validate(sm_json *string) error {
 	return nil
 }
 
-func (sm *StateMachine) FindTask(name string) (*state.TaskState, error) {
+func (sm *StateMachine) FindTask(name string) (*TaskState, error) {
 	task, ok := sm.Tasks()[name]
 
 	if !ok {
@@ -62,12 +61,12 @@ func (sm *StateMachine) FindTask(name string) (*state.TaskState, error) {
 	return task, nil
 }
 
-func (sm *StateMachine) Tasks() map[string]*state.TaskState {
-	tasks := map[string]*state.TaskState{}
+func (sm *StateMachine) Tasks() map[string]*TaskState {
+	tasks := map[string]*TaskState{}
 	for name, s := range sm.States {
 		switch s.(type) {
-		case *state.TaskState:
-			tasks[name] = s.(*state.TaskState)
+		case *TaskState:
+			tasks[name] = s.(*TaskState)
 		}
 	}
 	return tasks

--- a/machine/map_state.go
+++ b/machine/map_state.go
@@ -13,11 +13,11 @@ type MapState struct {
 	Type    *string
 	Comment *string `json:",omitempty"`
 
-	Iterator  *StateMachine
-	ItemsPath *jsonpath.Path `json:",omitempty"`
+	Iterator   *StateMachine
+	ItemsPath  *jsonpath.Path `json:",omitempty"`
 	Parameters interface{}    `json:",omitempty"`
 
-	MaxConcurrency     *float64       `json:",omitempty"`
+	MaxConcurrency *float64 `json:",omitempty"`
 
 	InputPath  *jsonpath.Path `json:",omitempty"`
 	OutputPath *jsonpath.Path `json:",omitempty"`
@@ -35,15 +35,17 @@ func (s *MapState) process(ctx context.Context, input interface{}) (interface{},
 	if err != nil {
 		return input, nextState(s.Next, s.End), err
 	}
-	outputResults := []interface{}{}
+	var res []map[string]interface{}
+
 	for _, item := range output {
 		execution, err := s.Iterator.Execute(item)
 		if err != nil {
 			return input, nextState(s.Next, s.End), err
 		}
-		outputResults = append(outputResults, execution.Output)
+		res = append(res, execution.Output)
 	}
-	return outputResults, nextState(s.Next, s.End), nil
+
+	return res, nextState(s.Next, s.End), nil
 }
 
 func (s *MapState) Execute(ctx context.Context, input interface{}) (output interface{}, next *string, err error) {
@@ -78,7 +80,7 @@ func (s *MapState) Validate() error {
 		return fmt.Errorf("%v Requires Iterator", errorPrefix(s))
 	}
 
-	if err:= s.Iterator.Validate(); err != nil {
+	if err := s.Iterator.Validate(); err != nil {
 		return fmt.Errorf("%v %v", errorPrefix(s), err)
 	}
 	return nil

--- a/machine/map_state.go
+++ b/machine/map_state.go
@@ -1,0 +1,93 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"github.com/coinbase/step/jsonpath"
+	"github.com/coinbase/step/utils/to"
+)
+
+type MapState struct {
+	stateStr // Include Defaults
+
+	Type    *string
+	Comment *string `json:",omitempty"`
+
+	Iterator  *StateMachine
+	ItemsPath *jsonpath.Path `json:",omitempty"`
+	Parameters interface{}    `json:",omitempty"`
+
+	MaxConcurrency     *float64       `json:",omitempty"`
+
+	InputPath  *jsonpath.Path `json:",omitempty"`
+	OutputPath *jsonpath.Path `json:",omitempty"`
+	ResultPath *jsonpath.Path `json:",omitempty"`
+
+	Catch []*Catcher `json:",omitempty"`
+	Retry []*Retrier `json:",omitempty"`
+
+	Next *string `json:",omitempty"`
+	End  *bool   `json:",omitempty"`
+}
+
+func (s *MapState) process(ctx context.Context, input interface{}) (interface{}, *string, error) {
+	output, err := s.ItemsPath.GetSlice(input)
+	if err != nil {
+		return input, nextState(s.Next, s.End), err
+	}
+	outputResults := []interface{}{}
+	for _, item := range output {
+		execution, err := s.Iterator.Execute(item)
+		if err != nil {
+			return input, nextState(s.Next, s.End), err
+		}
+		outputResults = append(outputResults, execution.Output)
+	}
+	return outputResults, nextState(s.Next, s.End), nil
+}
+
+func (s *MapState) Execute(ctx context.Context, input interface{}) (output interface{}, next *string, err error) {
+	return processError(s,
+		processCatcher(s.Catch,
+			processRetrier(s.Name(), s.Retry,
+				inputOutput(
+					s.InputPath,
+					s.OutputPath,
+					withParams(
+						s.Parameters,
+						result(s.ResultPath, s.process),
+					),
+				),
+			),
+		),
+	)(ctx, input)
+}
+
+func (s *MapState) Validate() error {
+	s.SetType(to.Strp("Map"))
+
+	if err := ValidateNameAndType(s); err != nil {
+		return fmt.Errorf("%v %v", errorPrefix(s), err)
+	}
+
+	if err := endValid(s.Next, s.End); err != nil {
+		return fmt.Errorf("%v %v", errorPrefix(s), err)
+	}
+
+	if s.Iterator == nil {
+		return fmt.Errorf("%v Requires Iterator", errorPrefix(s))
+	}
+
+	if err:= s.Iterator.Validate(); err != nil {
+		return fmt.Errorf("%v %v", errorPrefix(s), err)
+	}
+	return nil
+}
+
+func (s *MapState) SetType(t *string) {
+	s.Type = t
+}
+
+func (s *MapState) GetType() *string {
+	return s.Type
+}

--- a/machine/map_state_test.go
+++ b/machine/map_state_test.go
@@ -1,0 +1,97 @@
+package machine
+
+import (
+	"github.com/coinbase/step/utils/to"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+/////////
+// Helpers
+/////////
+
+func initialize_state_machine( state *StateMachine , t *testing.T) {
+	state.StartAt = to.Strp("Start")
+	state.States = States{}
+	sm := parseTaskState([]byte(`{
+		"Resource": "asd",
+		"Next": "Pass",
+		"Retry": [{ "ErrorEquals": ["States.ALL"] }]
+	}`), t)
+	state.States["start"] = sm
+
+}
+
+// Execution
+
+func Test_MapState_ValidateResource(t *testing.T) {
+	state := parseMapState([]byte(`{ "Next": "Pass"}`), t)
+	assert.Error(t, state.Validate())
+	state.Iterator = &StateMachine{}
+	assert.Error(t, state.Validate())
+	initialize_state_machine(state.Iterator, t)
+	assert.NoError(t, state.Validate())
+}
+
+func Test_MapState_SingleState(t *testing.T){
+	state := parseMapState([]byte(`{
+      "Type": "Map",
+      "ItemsPath": "$.shipped",
+      "ResultPath": "$.output",
+      "MaxConcurrency": 0,
+      "Iterator": {
+        "StartAt": "Validate",
+        "States": {
+          "Validate": {
+            "Type": "Pass",
+            "Result": {"key": "value"},
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }`), t)
+	// Default
+	 testState(state, stateTestData{
+		Input: map[string]interface{}{"shipped": []interface{}{1,2,3}},
+	}, t)
+
+	testState(state, stateTestData{
+		Input: map[string]interface{}{},
+		Error: to.Strp("GetSlice Error \"Not Found\""),
+	}, t)
+}
+
+func Test_MapState_Catch(t *testing.T){
+	state := parseMapState([]byte(`{
+      "Type": "Map",
+      "ItemsPath": "$.shipped",
+      "ResultPath": "$.output",
+      "MaxConcurrency": 0,
+      "Catch": [{
+			"ErrorEquals": ["States.ALL"],
+			"Next": "Fail"
+       }],
+      "Iterator": {
+        "StartAt": "Validate",
+        "States": {
+          "Validate": {
+            "Type": "Pass",
+            "Result": {"key": "value"},
+            "End": true
+          }
+        }
+      },
+      "End": true
+    }`), t)
+	// Default
+	testState(state, stateTestData{
+		Input: map[string]interface{}{"shipped": []interface{}{1,2,3}},
+	}, t)
+
+	// No Input path data. Should be caught
+	testState(state, stateTestData{
+		Input: map[string]interface{}{},
+	}, t)
+
+}

--- a/machine/map_state_test.go
+++ b/machine/map_state_test.go
@@ -10,7 +10,7 @@ import (
 // Helpers
 /////////
 
-func initialize_state_machine( state *StateMachine , t *testing.T) {
+func initialize_state_machine(state *StateMachine, t *testing.T) {
 	state.StartAt = to.Strp("Start")
 	state.States = States{}
 	sm := parseTaskState([]byte(`{
@@ -33,11 +33,12 @@ func Test_MapState_ValidateResource(t *testing.T) {
 	assert.NoError(t, state.Validate())
 }
 
-func Test_MapState_SingleState(t *testing.T){
+func Test_MapState_SingleState(t *testing.T) {
 	state := parseMapState([]byte(`{
       "Type": "Map",
       "ItemsPath": "$.shipped",
-      "ResultPath": "$.output",
+      "ResultPath": "$.output.data",
+      "OutputPath": "$.output",
       "MaxConcurrency": 0,
       "Iterator": {
         "StartAt": "Validate",
@@ -52,8 +53,16 @@ func Test_MapState_SingleState(t *testing.T){
       "End": true
     }`), t)
 	// Default
-	 testState(state, stateTestData{
-		Input: map[string]interface{}{"shipped": []interface{}{1,2,3}},
+	outputResults := map[string]interface{}{}
+	var res []map[string]interface{}
+	res = append(res, map[string]interface{}{"key": "value"})
+	res = append(res, map[string]interface{}{"key": "value"})
+	res = append(res, map[string]interface{}{"key": "value"})
+
+	outputResults["data"] = res
+	testState(state, stateTestData{
+		Input:  map[string]interface{}{"shipped": []interface{}{1, 2, 3}, "output": []interface{}{}},
+		Output: outputResults,
 	}, t)
 
 	testState(state, stateTestData{
@@ -62,11 +71,13 @@ func Test_MapState_SingleState(t *testing.T){
 	}, t)
 }
 
-func Test_MapState_Catch(t *testing.T){
+func Test_MapState_Catch(t *testing.T) {
 	state := parseMapState([]byte(`{
       "Type": "Map",
       "ItemsPath": "$.shipped",
-      "ResultPath": "$.output",
+      "ResultPath": "$.output.data",
+      "OutputPath": "$.output",
+
       "MaxConcurrency": 0,
       "Catch": [{
 			"ErrorEquals": ["States.ALL"],
@@ -84,14 +95,52 @@ func Test_MapState_Catch(t *testing.T){
       },
       "End": true
     }`), t)
-	// Default
-	testState(state, stateTestData{
-		Input: map[string]interface{}{"shipped": []interface{}{1,2,3}},
-	}, t)
 
 	// No Input path data. Should be caught
 	testState(state, stateTestData{
 		Input: map[string]interface{}{},
+		Output: map[string]interface{}{"Error": "errorString", "Cause": "GetSlice Error \"Not Found\""},
 	}, t)
 
+}
+
+func Test_MapState_Integration(t *testing.T) {
+	state := parseMapState([]byte(`{
+      "Type": "Map",
+      "ItemsPath": "$.shipped",
+      "ResultPath": "$.output.data",
+      "OutputPath": "$.output",
+      "MaxConcurrency": 0,
+      "Iterator": {
+        "StartAt": "Validate",
+        "States": {
+          "Validate": {
+            "Type": "Pass",
+            "Next": "Task"
+          },
+          "Task" : {
+			"Type": "TaskFn",
+			"Resource": "arn:aws:lambda:{{aws_region}}:{{aws_account}}:function:{{lambda_name}}",
+			"Result": {"key": "value"},
+			"End": true
+         }
+        }
+      },
+      "End": true
+    }`), t)
+
+	// Default
+	var task = state.Iterator.States["Task"].(*TaskState)
+	task.SetTaskHandler(ReturnInputHandler)
+	outputResults := map[string]interface{}{}
+	var res []map[string]interface{}
+	res = append(res, map[string]interface{}{"Task": "Task", "Input": float64(11)})
+	res = append(res, map[string]interface{}{"Task": "Task", "Input": float64(12)})
+	res = append(res, map[string]interface{}{"Task": "Task", "Input": float64(13)})
+
+	outputResults["data"] = res
+	testState(state, stateTestData{
+		Input:  map[string]interface{}{"shipped": []interface{}{11, 12, 13}, "output": []interface{}{}},
+		Output: outputResults,
+	}, t)
 }

--- a/machine/parallel_state.go
+++ b/machine/parallel_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/parser.go
+++ b/machine/parser.go
@@ -95,6 +95,10 @@ func unmarshallState(name string, raw_json *json.RawMessage) ([]State, error) {
 		var s ParallelState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
+	case "Map":
+		var s MapState
+		err = json.Unmarshal(*raw_json, &s)
+		newState = &s
 	case "TaskFn":
 		// This is a custom state that adds values to Task to be handled
 		var s TaskState

--- a/machine/parser.go
+++ b/machine/parser.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/coinbase/step/machine/state"
 	"github.com/coinbase/step/utils/to"
 )
 
@@ -56,7 +55,7 @@ type stateType struct {
 	Type string
 }
 
-func unmarshallState(name string, raw_json *json.RawMessage) ([]state.State, error) {
+func unmarshallState(name string, raw_json *json.RawMessage) ([]State, error) {
 	var err error
 
 	// extract type (safer than regex)
@@ -65,40 +64,40 @@ func unmarshallState(name string, raw_json *json.RawMessage) ([]state.State, err
 		return nil, err
 	}
 
-	var newState state.State
+	var newState State
 
 	switch state_type.Type {
 	case "Pass":
-		var s state.PassState
+		var s PassState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "Task":
-		var s state.TaskState
+		var s TaskState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "Choice":
-		var s state.ChoiceState
+		var s ChoiceState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "Wait":
-		var s state.WaitState
+		var s WaitState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "Succeed":
-		var s state.SucceedState
+		var s SucceedState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "Fail":
-		var s state.FailState
+		var s FailState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "Parallel":
-		var s state.ParallelState
+		var s ParallelState
 		err = json.Unmarshal(*raw_json, &s)
 		newState = &s
 	case "TaskFn":
 		// This is a custom state that adds values to Task to be handled
-		var s state.TaskState
+		var s TaskState
 		err = json.Unmarshal(*raw_json, &s)
 		// This will inject the Task name into the input
 		s.Parameters = map[string]interface{}{"Task": name, "Input.$": "$"}
@@ -117,5 +116,5 @@ func unmarshallState(name string, raw_json *json.RawMessage) ([]state.State, err
 	newName := name
 	newState.SetName(&newName) // Require New Variable Pointer
 
-	return []state.State{newState}, nil
+	return []State{newState}, nil
 }

--- a/machine/parser_test.go
+++ b/machine/parser_test.go
@@ -108,3 +108,10 @@ func Test_Machine_Parser_TaskFn(t *testing.T) {
 	assert.Equal(t, err, nil)
 	assert.NoError(t, sm.Validate())
 }
+
+func Test_Machine_Parser_Map(t *testing.T) {
+	sm, err := ParseFile("../examples/map.json")
+
+	assert.Equal(t, err, nil)
+	assert.NoError(t, sm.Validate())
+}

--- a/machine/parser_test.go
+++ b/machine/parser_test.go
@@ -111,7 +111,14 @@ func Test_Machine_Parser_TaskFn(t *testing.T) {
 
 func Test_Machine_Parser_Map(t *testing.T) {
 	sm, err := ParseFile("../examples/map.json")
-
+	var mapState *MapState
+	mapState = sm.States["Start"].(*MapState)
 	assert.Equal(t, err, nil)
 	assert.NoError(t, sm.Validate())
+	assert.Equal(t, "$.detail", mapState.InputPath.String(), )
+	assert.Equal(t, "$.shipped", mapState.ItemsPath.String(), )
+	assert.Equal(t, "$.detail.shipped", mapState.ResultPath.String(), )
+	assert.Equal(t, 1, len(mapState.Iterator.States))
+	assert.Equal(t, "Task", *mapState.Iterator.States["Validate"].GetType(), )
+
 }

--- a/machine/parser_test.go
+++ b/machine/parser_test.go
@@ -3,7 +3,6 @@ package machine
 import (
 	"testing"
 
-	"github.com/coinbase/step/machine/state"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,8 +53,8 @@ func Test_Parser_Expands_TaskFn(t *testing.T) {
 	assert.Equal(t, *sm.States["A"].GetType(), "Task")
 	assert.Equal(t, *sm.States["B"].GetType(), "Task")
 
-	ataskState := sm.States["A"].(*state.TaskState)
-	btaskState := sm.States["B"].(*state.TaskState)
+	ataskState := sm.States["A"].(*TaskState)
+	btaskState := sm.States["B"].(*TaskState)
 
 	// ORDER
 	assert.Equal(t, ataskState.Parameters, map[string]interface{}{"Task": "A", "Input.$": "$"})

--- a/machine/pass_state.go
+++ b/machine/pass_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/pass_state_test.go
+++ b/machine/pass_state_test.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"testing"

--- a/machine/state_test.go
+++ b/machine/state_test.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"encoding/json"

--- a/machine/state_test.go
+++ b/machine/state_test.go
@@ -86,3 +86,12 @@ func parseValidTaskState(b []byte, handler interface{}, t *testing.T) *TaskState
 	assert.NoError(t, state.Validate())
 	return state
 }
+
+func parseMapState(b []byte, t *testing.T) *MapState {
+	var p MapState
+	err := json.Unmarshal(b, &p)
+	assert.NoError(t, err)
+	p.SetName(to.Strp("TestState"))
+	p.SetType(to.Strp("Map"))
+	return &p
+}

--- a/machine/succeed_state.go
+++ b/machine/succeed_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/task_state.go
+++ b/machine/task_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/task_state_test.go
+++ b/machine/task_state_test.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/wait_state.go
+++ b/machine/wait_state.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"context"

--- a/machine/wait_state_test.go
+++ b/machine/wait_state_test.go
@@ -1,4 +1,4 @@
-package state
+package machine
 
 import (
 	"testing"


### PR DESCRIPTION
Adding support for [map state](https://states-language.net/spec.html#map-state) in step framework.
To do so, I needed to rearrange some packages to unblock circular dependencies conflict.
Additionally, I've added the `.idea` folder to the `.gitignore` file.