### PR TITLE
Remove S3 root lock, and rely on DynamoDB locking

### DIFF
--- a/aws/mocks/mock_dynamodb.go
+++ b/aws/mocks/mock_dynamodb.go
@@ -10,6 +10,9 @@ type MockDynamoDBClient struct {
 
 	PutItemInputs    []*dynamodb.PutItemInput
 	DeleteItemInputs []*dynamodb.DeleteItemInput
+
+	PutItemError    error
+	DeleteItemError error
 }
 
 func (m *MockDynamoDBClient) init() {
@@ -23,11 +26,19 @@ func (m *MockDynamoDBClient) init() {
 }
 
 func (m *MockDynamoDBClient) PutItem(input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
+	if m.PutItemError != nil {
+		return nil, m.PutItemError
+	}
+
 	m.PutItemInputs = append(m.PutItemInputs, input)
 	return &dynamodb.PutItemOutput{}, nil
 }
 
 func (m *MockDynamoDBClient) DeleteItem(input *dynamodb.DeleteItemInput) (*dynamodb.DeleteItemOutput, error) {
+	if m.DeleteItemError != nil {
+		return nil, m.DeleteItemError
+	}
+
 	m.DeleteItemInputs = append(m.DeleteItemInputs, input)
 	return &dynamodb.DeleteItemOutput{}, nil
 }

--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -241,12 +241,7 @@ func (r *Release) TimedOut() error {
 ///////
 
 // UnlockRootLock deletes the Lock File for the release
-func (r *Release) UnlockRoot(s3c aws.S3API, locker Locker, lockTableName string) error {
-	err := s3.ReleaseLock(s3c, r.Bucket, r.RootLockPath(), *r.UUID)
-	if err != nil {
-		return err
-	}
-
+func (r *Release) UnlockRoot(locker Locker, lockTableName string) error {
 	return locker.ReleaseLock(lockTableName, *r.RootLockPath(), *r.UUID)
 }
 
@@ -260,20 +255,14 @@ func (r *Release) GrabLocks(s3c aws.S3API, locker Locker, lockTableName string) 
 		return err
 	}
 
-	if err := r.GrabRootLock(s3c, locker, lockTableName); err != nil {
+	if err := r.GrabRootLock(locker, lockTableName); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (r *Release) GrabRootLock(s3c aws.S3API, locker Locker, lockTableName string) error {
-	// DEPRECATED: this will gradually be replaced by `grabGenericLock` (below).
-	err := r.grabS3Lock(s3c, *r.RootLockPath())
-	if err != nil {
-		return err
-	}
-
+func (r *Release) GrabRootLock(locker Locker, lockTableName string) error {
 	return r.grabGenericLock(locker, lockTableName, *r.RootLockPath())
 }
 
@@ -289,8 +278,6 @@ func (r *Release) CheckUserLock(s3c aws.S3API, lockPath string) error {
 	return nil
 }
 
-// DEPRECATED: this will gradually be replaced by `grabGenericLock` (below),
-// but it is currently preserved for backwards compatibility.
 func (r *Release) grabS3Lock(s3c aws.S3API, lockPath string) error {
 	grabbed, err := s3.GrabLock(s3c, r.Bucket, &lockPath, *r.UUID)
 

--- a/bifrost/release.go
+++ b/bifrost/release.go
@@ -302,8 +302,8 @@ func (r *Release) grabS3Lock(s3c aws.S3API, lockPath string) error {
 
 		return &errors.LockExistsError{
 			fmt.Sprintf(
-				"S3 Lock Already Exists at %v:%v\nRun the following to clear it: " +
-				"aws s3 rm s3://%[1]v/%[2]v",
+				"S3 Lock Already Exists at %v:%v\nRun the following to clear it: "+
+					"aws s3 rm s3://%[1]v/%[2]v",
 				*r.Bucket, lockPath,
 			),
 		}
@@ -328,8 +328,8 @@ func (r *Release) grabGenericLock(locker Locker, lockTableName string, lockPath 
 
 		return &errors.LockExistsError{
 			fmt.Sprintf(
-				"Lock Already Exists at %v:%v\nRun the following to clear it: " +
-				"aws dynamodb delete-item --table-name %[1]v --key='{\"key\": {\"S\": \"%[2]v\" }}'",
+				"Lock Already Exists at %v:%v\nRun the following to clear it: "+
+					"aws dynamodb delete-item --table-name %[1]v --key='{\"key\": {\"S\": \"%[2]v\" }}'",
 				lockTableName, lockPath,
 			),
 		}

--- a/bifrost/release_lock_test.go
+++ b/bifrost/release_lock_test.go
@@ -9,20 +9,20 @@ import (
 
 func Test_Lock_GrabRootLock(t *testing.T) {
 	r := MockRelease()
+	r.ReleaseSHA256 = to.SHA256Struct(&r)
+	r.SetDefaults(r.AwsRegion, r.AwsAccountID, "")
 
 	r2 := MockRelease()
 	r2.UUID = to.Strp("NOTUUID")
 
-	awsc := MockAwsClients(r)
-	s3c := awsc.S3Client(nil, nil, nil)
 	locker := NewInMemoryLocker()
 
 	t.Run("root lock acquired", func(t *testing.T) {
-		assert.NoError(t, r.GrabRootLock(s3c, locker, "lambdaname"))
+		assert.NoError(t, r.GrabRootLock(locker, "lambdaname"))
 	})
 
 	t.Run("same root lock acquired", func(t *testing.T) {
-		assert.NoError(t, r.GrabRootLock(s3c, locker, "lambdaname"))
+		assert.NoError(t, r.GrabRootLock(locker, "lambdaname"))
 
 		locks := locker.GetLockByNamespace("lambdaname")
 		// We are re-using an existing lock
@@ -31,23 +31,23 @@ func Test_Lock_GrabRootLock(t *testing.T) {
 	})
 
 	t.Run("conflict when acquiring root lock with different uuid", func(t *testing.T) {
-		assert.Error(t, r2.GrabRootLock(s3c, locker, "lambdaname"))
+		assert.Error(t, r2.GrabRootLock(locker, "lambdaname"))
 		// There should be no changes in the existing locks
 		assert.Equal(t, len(locker.GetLockByNamespace("lambdaname")), 1)
 	})
 
 	t.Run("root lock released", func(t *testing.T) {
-		assert.NoError(t, r.UnlockRoot(s3c, locker, "lambdaname"))
+		assert.NoError(t, r.UnlockRoot(locker, "lambdaname"))
 		assert.Equal(t, len(locker.GetLockByNamespace("lambdaname")), 0)
 	})
 
 	t.Run("same root lock released", func(t *testing.T) {
-		assert.NoError(t, r.UnlockRoot(s3c, locker, "lambdaname"))
+		assert.NoError(t, r.UnlockRoot(locker, "lambdaname"))
 		assert.Equal(t, len(locker.GetLockByNamespace("lambdaname")), 0)
 	})
 
 	t.Run("root lock with same uuid acquired", func(t *testing.T) {
-		assert.NoError(t, r2.GrabRootLock(s3c, locker, "lambdaname"))
+		assert.NoError(t, r2.GrabRootLock(locker, "lambdaname"))
 		locks := locker.GetLockByNamespace("lambdaname")
 		assert.Equal(t, len(locks), 1)
 		assert.Equal(t, locks[0].lockPath, "account/project/config/lock")

--- a/deployer/handlers.go
+++ b/deployer/handlers.go
@@ -93,7 +93,7 @@ func DeployHandler(awsc aws.AwsClients) interface{} {
 
 		release.Success = to.Boolp(true)
 		locker := dynamodb.NewDynamoDBLocker(awsc.DynamoDBClient(nil, nil, nil))
-		release.UnlockRoot(awsc.S3Client(nil, nil, nil), locker, getLockTableNameFromContext(ctx, "-locks"))
+		release.UnlockRoot(locker, getLockTableNameFromContext(ctx, "-locks"))
 
 		return release, nil
 	}
@@ -102,7 +102,7 @@ func DeployHandler(awsc aws.AwsClients) interface{} {
 func ReleaseLockFailureHandler(awsc aws.AwsClients) interface{} {
 	return func(ctx context.Context, release *Release) (*Release, error) {
 		locker := dynamodb.NewDynamoDBLocker(awsc.DynamoDBClient(nil, nil, nil))
-		if err := release.UnlockRoot(awsc.S3Client(nil, nil, nil), locker, getLockTableNameFromContext(ctx, "-locks")); err != nil {
+		if err := release.UnlockRoot(locker, getLockTableNameFromContext(ctx, "-locks")); err != nil {
 			return nil, errors.LockError{err.Error()}
 		}
 

--- a/deployer/helpers_test.go
+++ b/deployer/helpers_test.go
@@ -83,22 +83,12 @@ func createTestStateMachine(t *testing.T, awsc *mocks.MockClients) *machine.Stat
 	return stateMachine
 }
 
-func assertNoRootLock(t *testing.T, awsc aws.AwsClients, release *Release) {
-	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.RootLockPath())
-	assert.Error(t, err) // Not found error
-	assert.IsType(t, &s3.NotFoundError{}, err)
-}
-
-func assertNoRootLockWithReleseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
-	assertNoRootLock(t, awsc, release)
-
+func assertHasReleaseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
 	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleaseLockPath())
 	assert.NoError(t, err) // Not error
 }
 
-func assertNoRootLockNoReleseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
-	assertNoRootLock(t, awsc, release)
-
+func assertNoReleaseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
 	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleaseLockPath())
 	assert.Error(t, err) // Not found error
 	assert.IsType(t, &s3.NotFoundError{}, err)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/coinbase/step
 go 1.14
 
 require (
-	github.com/DataDog/datadog-lambda-go v0.6.0 // indirect
+	github.com/DataDog/datadog-lambda-go v0.6.0
 	github.com/aws/aws-lambda-go v1.17.0
 	github.com/aws/aws-sdk-go v1.31.8
 	github.com/aws/aws-xray-sdk-go v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,7 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/urfave/cli/v2 v2.1.1/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -61,4 +62,5 @@ golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/jsonpath/jsonpath.go
+++ b/jsonpath/jsonpath.go
@@ -208,7 +208,7 @@ func (path *Path) Get(input interface{}) (value interface{}, err error) {
 
 // GetSlice returns array from Path
 
-func (path *Path) GetSlice(input interface{}) (output []interface{}, err error ) {
+func (path *Path) GetSlice(input interface{}) (output []interface{}, err error) {
 	output_value, err := path.Get(input)
 
 	if err != nil {

--- a/jsonpath/jsonpath_get_test.go
+++ b/jsonpath/jsonpath_get_test.go
@@ -124,7 +124,7 @@ func Test_JSONPath_GetString(t *testing.T) {
 }
 
 func Test_JSONPath_GetSplice(t *testing.T) {
-	test := []interface{}{1,2,3}
+	test := []interface{}{1, 2, 3}
 	outer := map[string]interface{}{"x": test}
 
 	path, err := NewPath("$.x")

--- a/machine/map_state_test.go
+++ b/machine/map_state_test.go
@@ -98,7 +98,7 @@ func Test_MapState_Catch(t *testing.T) {
 
 	// No Input path data. Should be caught
 	testState(state, stateTestData{
-		Input: map[string]interface{}{},
+		Input:  map[string]interface{}{},
 		Output: map[string]interface{}{"Error": "errorString", "Cause": "GetSlice Error \"Not Found\""},
 	}, t)
 

--- a/machine/parser_test.go
+++ b/machine/parser_test.go
@@ -115,10 +115,10 @@ func Test_Machine_Parser_Map(t *testing.T) {
 	mapState = sm.States["Start"].(*MapState)
 	assert.Equal(t, err, nil)
 	assert.NoError(t, sm.Validate())
-	assert.Equal(t, "$.detail", mapState.InputPath.String(), )
-	assert.Equal(t, "$.shipped", mapState.ItemsPath.String(), )
-	assert.Equal(t, "$.detail.shipped", mapState.ResultPath.String(), )
+	assert.Equal(t, "$.detail", mapState.InputPath.String())
+	assert.Equal(t, "$.shipped", mapState.ItemsPath.String())
+	assert.Equal(t, "$.detail.shipped", mapState.ResultPath.String())
 	assert.Equal(t, 1, len(mapState.Iterator.States))
-	assert.Equal(t, "Task", *mapState.Iterator.States["Validate"].GetType(), )
+	assert.Equal(t, "Task", *mapState.Iterator.States["Validate"].GetType())
 
 }


### PR DESCRIPTION
We recently introduced DynamoDB for root locking (a93d5f02),
but we did not remove the use of S3 for root locking.
The reason for this was so that we can gracefully migrate all deployers,
otherwise there will be some deployers (in an environment) relying on
DynamoDB, and some deployers relying on S3 which may result in
some overlaps not being caught.

Now that the deployers have been migrated over, we can remove
the use of S3 for root locking. We will still be using it for
user locking, and release locking as both of those are less likely
to run into race conditions, and the release lock is more of an
idempotency key which we never remove / clean up.

The `Test_DeployHandler_Execution_Errors_Root_LockError` test
was removed as we should never reach a state where we have
acquired a lock, but with an error in the process of doing so.
We may have future implementations that does this, but in terms
of integration testing, our DynamoDB implementation will either
succeed in acquiring a lock without any error or fail.
The `LockError` condition will not be triggered.

The `assertNoRootLockWithReleseLock`, and `assertNoRootLockNoReleseLock`
were also replaced with `assertHasReleaseLock`, `assertNoReleaseLock`,
and checks on the lock items that were added, and/or removed from DynamoDB.