### PR TITLE
FIX - Use the release's region when deploying to regions other than w…

### DIFF
--- a/bifrost/release_lock_test.go
+++ b/bifrost/release_lock_test.go
@@ -14,7 +14,7 @@ func Test_Lock_GrabRootLock(t *testing.T) {
 	r2.UUID = to.Strp("NOTUUID")
 
 	awsc := MockAwsClients(r)
-	s3c := awsc.S3Client(nil, nil, nil)
+	s3c := awsc.S3Client(r.AwsRegion, nil, nil)
 	locker := NewInMemoryLocker()
 
 	t.Run("root lock acquired", func(t *testing.T) {

--- a/bifrost/release_test.go
+++ b/bifrost/release_test.go
@@ -54,5 +54,5 @@ func Test_Bifrost_Release_Is_Valid(t *testing.T) {
 	release := MockRelease()
 	awsc := MockAwsClients(release)
 
-	assert.NoError(t, release.Validate(awsc.S3Client(nil, nil, nil), &Release{}))
+	assert.NoError(t, release.Validate(awsc.S3Client(release.AwsRegion, nil, nil), &Release{}))
 }

--- a/client/client.go
+++ b/client/client.go
@@ -38,7 +38,7 @@ func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_fi
 	}
 
 	err := s3.PutFile(
-		awsc.S3Client(nil, nil, nil),
+		awsc.S3Client(release.AwsRegion, nil, nil),
 		zip_file_path,
 		release.Bucket,
 		release.LambdaZipPath(),
@@ -52,7 +52,7 @@ func PrepareReleaseBundle(awsc aws.AwsClients, release *deployer.Release, zip_fi
 	release.CreatedAt = to.Timep(time.Now())
 
 	// Uploading the Release to S3 to match SHAs
-	if err := s3.PutStruct(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleasePath(), release); err != nil {
+	if err := s3.PutStruct(awsc.S3Client(release.AwsRegion, nil, nil), release.Bucket, release.ReleasePath(), release); err != nil {
 		return err
 	}
 

--- a/deployer/helpers_test.go
+++ b/deployer/helpers_test.go
@@ -84,7 +84,7 @@ func createTestStateMachine(t *testing.T, awsc *mocks.MockClients) *machine.Stat
 }
 
 func assertNoRootLock(t *testing.T, awsc aws.AwsClients, release *Release) {
-	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.RootLockPath())
+	_, err := s3.Get(awsc.S3Client(release.AwsRegion, nil, nil), release.Bucket, release.RootLockPath())
 	assert.Error(t, err) // Not found error
 	assert.IsType(t, &s3.NotFoundError{}, err)
 }
@@ -92,14 +92,14 @@ func assertNoRootLock(t *testing.T, awsc aws.AwsClients, release *Release) {
 func assertNoRootLockWithReleseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
 	assertNoRootLock(t, awsc, release)
 
-	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleaseLockPath())
+	_, err := s3.Get(awsc.S3Client(release.AwsRegion, nil, nil), release.Bucket, release.ReleaseLockPath())
 	assert.NoError(t, err) // Not error
 }
 
 func assertNoRootLockNoReleseLock(t *testing.T, awsc aws.AwsClients, release *Release) {
 	assertNoRootLock(t, awsc, release)
 
-	_, err := s3.Get(awsc.S3Client(nil, nil, nil), release.Bucket, release.ReleaseLockPath())
+	_, err := s3.Get(awsc.S3Client(release.AwsRegion, nil, nil), release.Bucket, release.ReleaseLockPath())
 	assert.Error(t, err) // Not found error
 	assert.IsType(t, &s3.NotFoundError{}, err)
 }


### PR DESCRIPTION
…hat the step deployer is deployed in

When trying to deploy a step deployer to a region other than what the deployer is already deployed in, the step deployer tries to use its host region. 

Here, we are making a change to make the step deployer use the release's region when working with s3 because all release materials will be in an s3 bucket specific to that region. 